### PR TITLE
Update alignment and fix horizontal scrolling in editor

### DIFF
--- a/frost/assets/css/style-editor.css
+++ b/frost/assets/css/style-editor.css
@@ -39,18 +39,14 @@ img {
  * https://github.com/WordPress/gutenberg/issues/35884
 ---------------------------------------------*/
 
-.wp-site-blocks,
-body > .is-root-container,
 .edit-post-visual-editor__post-title-wrapper,
-.wp-block-group.alignfull,
-.wp-block-cover.alignfull,
+body > .is-root-container,
 .is-root-container .wp-block[data-align="full"] > .wp-block-group,
 .is-root-container .wp-block[data-align="full"] > .wp-block-cover {
 	padding-left: var(--wp--custom--spacing--outer);
 	padding-right: var(--wp--custom--spacing--outer);
 }
 
-.wp-site-blocks .alignfull,
 .is-root-container .wp-block[data-align="full"] {
 	margin-left: calc(-1 * var(--wp--custom--spacing--outer)) !important;
 	margin-right: calc(-1 * var(--wp--custom--spacing--outer)) !important;

--- a/frost/assets/css/style-editor.css
+++ b/frost/assets/css/style-editor.css
@@ -26,6 +26,37 @@ img {
 	vertical-align: top;
 }
 
+/*
+ * Alignment Styles - Originally from TT2.
+ * These rules are temporary, and should not
+ * be relied on or modified too heavily by
+ * themes or plugins that build on Frost.
+ * These are meant to be a precursor to a
+ * global solution provided by the Block Editor.
+ *
+ * Relevant issues:
+ * https://github.com/WordPress/gutenberg/issues/35607
+ * https://github.com/WordPress/gutenberg/issues/35884
+---------------------------------------------*/
+
+.wp-site-blocks,
+body > .is-root-container,
+.edit-post-visual-editor__post-title-wrapper,
+.wp-block-group.alignfull,
+.wp-block-cover.alignfull,
+.is-root-container .wp-block[data-align="full"] > .wp-block-group,
+.is-root-container .wp-block[data-align="full"] > .wp-block-cover {
+	padding-left: var(--wp--custom--spacing--outer);
+	padding-right: var(--wp--custom--spacing--outer);
+}
+
+.wp-site-blocks .alignfull,
+.is-root-container .wp-block[data-align="full"] {
+	margin-left: calc(-1 * var(--wp--custom--spacing--outer)) !important;
+	margin-right: calc(-1 * var(--wp--custom--spacing--outer)) !important;
+	width: unset;
+}
+
 /* Buttons
 --------------------------------------------- */
 
@@ -426,12 +457,4 @@ p.has-background {
 
 .is-style-no-margin {
 	margin: 0;
-}
-
-/* Layout
---------------------------------------------- */
-
-.is-root-container .wp-block[data-align="full"] {
-	margin-left: calc(-100vw / 2 + 100% / 2) !important;
-	margin-right: calc(-100vw / 2 + 100% / 2) !important;
 }

--- a/frost/inc/patterns/header/header-default-black-background.php
+++ b/frost/inc/patterns/header/header-default-black-background.php
@@ -9,8 +9,8 @@ return array(
 	'title'      => __( 'Header with site title, navigation.', 'frost' ),
 	'categories' => array( 'frost-header' ),
 	'blockTypes' => array( 'core/template-part/header' ),
-	'content'    => '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"30px","right":"40px","bottom":"30px","left":"40px"}}},"backgroundColor":"black","layout":{"inherit":true}} -->
-				<div class="wp-block-group alignfull has-black-background-color has-background" style="padding-top:30px;padding-right:40px;padding-bottom:30px;padding-left:40px">
+	'content'    => '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"30px","right":"30px","bottom":"30px","left":"30px"}}},"backgroundColor":"black","layout":{"inherit":true}} -->
+				<div class="wp-block-group alignfull has-black-background-color has-background" style="padding-top:30px;padding-right:30px;padding-bottom:30px;padding-left:30px">
 				<!-- wp:group {"align":"wide","layout":{"type":"flex","justifyContent":"space-between"}} -->
 				<div class="wp-block-group alignwide">
 				<!-- wp:site-title {"style":{"elements":{"link":{"color":{"text":"var:preset|color|white"}}}}} /-->

--- a/frost/inc/patterns/header/header-default.php
+++ b/frost/inc/patterns/header/header-default.php
@@ -9,8 +9,8 @@ return array(
 	'title'      => __( 'Header with site title, navigation.', 'frost' ),
 	'categories' => array( 'frost-header' ),
 	'blockTypes' => array( 'core/template-part/header' ),
-	'content'    => '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"30px","right":"40px","bottom":"30px","left":"40px"}}},"layout":{"inherit":true}} -->
-				<div class="wp-block-group alignfull" style="padding-top:30px;padding-right:40px;padding-bottom:30px;padding-left:40px">
+	'content'    => '<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"30px","right":"30px","bottom":"30px","left":"30px"}}},"layout":{"inherit":true}} -->
+				<div class="wp-block-group alignfull" style="padding-top:30px;padding-right:30px;padding-bottom:30px;padding-left:30px">
 				<!-- wp:group {"align":"wide","layout":{"type":"flex","justifyContent":"space-between"}} -->
 				<div class="wp-block-group alignwide">
 				<!-- wp:site-title /-->

--- a/frost/parts/footer.html
+++ b/frost/parts/footer.html
@@ -1,1 +1,5 @@
-<!-- wp:pattern {"slug":"frost/footer/footer-default-black-background"} /-->
+<!-- wp:group {"layout":{"inherit":true}} -->
+<div class="wp-block-group">
+    <!-- wp:pattern {"slug":"frost/footer/footer-default-black-background"} /-->
+</div>
+<!-- /wp:group -->

--- a/frost/parts/header.html
+++ b/frost/parts/header.html
@@ -1,1 +1,5 @@
-<!-- wp:pattern {"slug":"frost/header/header-default"} /-->
+<!-- wp:group {"layout":{"inherit":true}} -->
+<div class="wp-block-group">
+    <!-- wp:pattern {"slug":"frost/header/header-default"} /-->
+</div>
+<!-- /wp:group -->

--- a/frost/style.css
+++ b/frost/style.css
@@ -68,6 +68,32 @@ blockquote {
 	margin: 0;
 }
 
+/*
+ * Alignment Styles - Originally from TT2.
+ * These rules are temporary, and should not
+ * be relied on or modified too heavily by
+ * themes or plugins that build on Frost.
+ * These are meant to be a precursor to a
+ * global solution provided by the Block Editor.
+ *
+ * Relevant issues:
+ * https://github.com/WordPress/gutenberg/issues/35607
+ * https://github.com/WordPress/gutenberg/issues/35884
+---------------------------------------------*/
+
+.wp-site-blocks,
+.wp-block-group.alignfull,
+.wp-block-cover.alignfull {
+	padding-left: var(--wp--custom--spacing--outer);
+	padding-right: var(--wp--custom--spacing--outer);
+}
+
+.wp-site-blocks .alignfull {
+	margin-left: calc(-1 * var(--wp--custom--spacing--outer)) !important;
+	margin-right: calc(-1 * var(--wp--custom--spacing--outer)) !important;
+	width: unset;
+}
+
 /* Site Blocks
 ---------------------------------------------------------------------------- */
 
@@ -106,7 +132,7 @@ blockquote {
 }
 
 .wp-block-navigation__responsive-container.is-menu-open {
-	padding: 35px 40px;
+	padding: 30px var(--wp--custom--spacing--outer);
 }
 
 .wp-block-navigation:not(.has-background) .wp-block-navigation__submenu-container {
@@ -434,20 +460,6 @@ img {
 	margin-left: 30px;
 }
 
-/* Layout
---------------------------------------------- */
-
-.wp-site-blocks .alignfull {
-	margin-left: calc(-100vw / 2 + 100% / 2) !important;
-	margin-right: calc(-100vw / 2 + 100% / 2) !important;
-	max-width: 100vw;
-}
-
-.wp-block-group.alignfull {
-	padding-left: 40px;
-	padding-right: 40px;
-}
-
 /* Paragraph
 --------------------------------------------- */
 
@@ -618,16 +630,6 @@ p.has-background {
 ---------------------------------------------------------------------------- */
 
 @media only screen and (min-width: 800px) {
-
-
-	/* Layout
-	--------------------------------------------- */
-
-	.wp-site-blocks .alignwide {
-		margin-left: -280px;
-		margin-right: -280px;
-		max-width: 1200px;
-	}
 
 	/* Navigation
 	--------------------------------------------- */

--- a/frost/templates/404.html
+++ b/frost/templates/404.html
@@ -1,6 +1,6 @@
 <!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header"} /-->
-<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"top":"80px","right":"40px","bottom":"80px","left":"40px"}}}} -->
-<main class="site-content wp-block-group" style="padding-top:80px;padding-right:40px;padding-bottom:80px;padding-left:40px">
+<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"top":"80px","bottom":"80px"}}}} -->
+<main class="site-content wp-block-group" style="padding-top:80px;padding-bottom:80px">
 	<!-- wp:group {"layout":{"inherit":true}} -->
 	<div class="wp-block-group">
 		<!-- wp:pattern {"slug":"frost/hidden/hidden-404"} /-->

--- a/frost/templates/blank.html
+++ b/frost/templates/blank.html
@@ -1,5 +1,5 @@
-<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"right":"40px","left":"40px"}}}} -->
-<main class="site-content wp-block-group" style="padding-right:40px;padding-left:40px">
+<!-- wp:group {"tagName":"main"} -->
+<main class="site-content wp-block-group">
 	<!-- wp:post-content {"layout":{"inherit":true}} /-->
 </main>
 <!-- /wp:group -->

--- a/frost/templates/home.html
+++ b/frost/templates/home.html
@@ -1,6 +1,6 @@
 <!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header"} /-->
-<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"right":"40px","left":"40px"}}}} -->
-<main class="site-content wp-block-group" style="padding-right:40px;padding-left:40px">
+<!-- wp:group {"tagName":"main"} -->
+<main class="site-content wp-block-group">
 	<!-- wp:group {"layout":{"inherit":true}} -->
 	<div class="wp-block-group">
 		<!-- wp:pattern {"slug":"frost/page/page-home"} /-->

--- a/frost/templates/index.html
+++ b/frost/templates/index.html
@@ -1,6 +1,6 @@
 <!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header"} /-->
-<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"}}},"className":"site-content"} -->
-<main class="wp-block-group site-content" style="padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px">
+<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"top":"40px","bottom":"40px"}}},"className":"site-content"} -->
+<main class="wp-block-group site-content" style="padding-top:40px;padding-bottom:40px">
 	<!-- wp:query {"query":{"perPage":"5","pages":0,"offset":0,"postType":"post","categoryIds":[],"tagIds":[],"order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"layout":{"inherit":true}} -->
 	<div class="wp-block-query">
 		<!-- wp:post-template -->

--- a/frost/templates/no-title.html
+++ b/frost/templates/no-title.html
@@ -1,6 +1,6 @@
 <!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header"} /-->
-<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"right":"40px","left":"40px"}}}} -->
-<main class="site-content wp-block-group" style="padding-right:40px;padding-left:40px">
+<!-- wp:group {"tagName":"main"} -->
+<main class="site-content wp-block-group">
 	<!-- wp:post-content {"layout":{"inherit":true}} /-->
 </main>
 <!-- /wp:group -->

--- a/frost/templates/page.html
+++ b/frost/templates/page.html
@@ -1,6 +1,6 @@
 <!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header"} /-->
-<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"}}}} -->
-<main class="site-content wp-block-group" style="padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px">
+<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"top":"40px","bottom":"40px"}}}} -->
+<main class="site-content wp-block-group" style="padding-top:40px;padding-bottom:40px">
 	<!-- wp:group {"layout":{"inherit":true}} -->
 	<div class="wp-block-group">
 		<!-- wp:post-title {"level":1} /-->

--- a/frost/templates/single.html
+++ b/frost/templates/single.html
@@ -1,6 +1,6 @@
 <!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header"} /-->
-<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"}}}} -->
-<main class="site-content wp-block-group" style="padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px">
+<!-- wp:group {"tagName":"main","style":{"spacing":{"padding":{"top":"40px","bottom":"40px"}}}} -->
+<main class="site-content wp-block-group" style="padding-top:40px;padding-bottom:40px">
 	<!-- wp:group {"layout":{"inherit":true}} -->
 	<div class="wp-block-group">
 		<!-- wp:post-title {"level":1} /-->

--- a/frost/theme.json
+++ b/frost/theme.json
@@ -112,6 +112,9 @@
 				"heading": 1.1,
 				"medium": 1.5,
 				"body": 1.75
+			},
+			"spacing": {
+				"outer": "40px"
 			}
 		},
 		"layout": {

--- a/frost/theme.json
+++ b/frost/theme.json
@@ -114,7 +114,7 @@
 				"body": 1.75
 			},
 			"spacing": {
-				"outer": "40px"
+				"outer": "30px"
 			}
 		},
 		"layout": {


### PR DESCRIPTION
Fixes #12 

This PR introduces similar alignment styles [as used](https://github.com/WordPress/twentytwentytwo/commit/cdcdf4ae5e1b01eb871bff5ebda8f232727d2647#diff-b78be019f1dc6d57753ea900c3805b114cd53ab7c0db836cc081836df1b99b7a) in the Twenty Twenty-Two theme and fixes a number of minor bugs in the block editor including #12.  

We also have introduced a custom variable in theme.json for controlling the "outer" padding for the theme. 