### PR TITLE
Frost: Fix spacer block error in WordPress 5.9

### DIFF
--- a/frost/inc/patterns/call-to-action/call-to-action-button-black-background.php
+++ b/frost/inc/patterns/call-to-action/call-to-action-button-black-background.php
@@ -9,7 +9,7 @@ return array(
 	'title'      => __( 'Call-to-action with text, button.', 'frost' ),
 	'categories' => array( 'frost-call-to-action' ),
 	'content'    => '<!-- wp:group {"align":"full","backgroundColor":"black","textColor":"white","layout":{"inherit":true}} -->
-				<div class="wp-block-group alignfull has-white-color has-black-background-color has-text-color has-background"><!-- wp:spacer -->
+				<div class="wp-block-group alignfull has-white-color has-black-background-color has-text-color has-background"><!-- wp:spacer {"height":100} -->
 				<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
@@ -29,7 +29,7 @@ return array(
 				<!-- /wp:column --></div>
 				<!-- /wp:columns -->
 
-				<!-- wp:spacer {"height":"70px"} -->
+				<!-- wp:spacer {"height":70} -->
 				<div style="height:70px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer --></div>
 				<!-- /wp:group -->',

--- a/frost/inc/patterns/call-to-action/call-to-action-button.php
+++ b/frost/inc/patterns/call-to-action/call-to-action-button.php
@@ -9,7 +9,7 @@ return array(
 	'title'      => __( 'Call-to-action with text, button.', 'frost' ),
 	'categories' => array( 'frost-call-to-action' ),
 	'content'    => '<!-- wp:group {"align":"full","layout":{"inherit":true}} -->
-				<div class="wp-block-group alignfull"><!-- wp:spacer -->
+				<div class="wp-block-group alignfull"><!-- wp:spacer {"height":100} -->
 				<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
@@ -29,7 +29,7 @@ return array(
 				<!-- /wp:column --></div>
 				<!-- /wp:columns -->
 
-				<!-- wp:spacer {"height":"70px"} -->
+				<!-- wp:spacer {"height":70} -->
 				<div style="height:70px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer --></div>
 				<!-- /wp:group -->',

--- a/frost/inc/patterns/call-to-action/call-to-action-buttons-black-background.php
+++ b/frost/inc/patterns/call-to-action/call-to-action-buttons-black-background.php
@@ -9,7 +9,7 @@ return array(
 	'title'      => __( 'Call-to-action with text, buttons.', 'frost' ),
 	'categories' => array( 'frost-call-to-action' ),
 	'content'    => '<!-- wp:group {"align":"full","backgroundColor":"black","textColor":"white","layout":{"inherit":true}} -->
-				<div class="wp-block-group alignfull has-white-color has-black-background-color has-text-color has-background"><!-- wp:spacer -->
+				<div class="wp-block-group alignfull has-white-color has-black-background-color has-text-color has-background"><!-- wp:spacer {"height":100} -->
 				<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
@@ -33,7 +33,7 @@ return array(
 				<!-- /wp:column --></div>
 				<!-- /wp:columns -->
 
-				<!-- wp:spacer {"height":"70px"} -->
+				<!-- wp:spacer {"height":70} -->
 				<div style="height:70px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer --></div>
 				<!-- /wp:group -->',

--- a/frost/inc/patterns/call-to-action/call-to-action-buttons.php
+++ b/frost/inc/patterns/call-to-action/call-to-action-buttons.php
@@ -9,7 +9,7 @@ return array(
 	'title'      => __( 'Call-to-action with text, buttons.', 'frost' ),
 	'categories' => array( 'frost-call-to-action' ),
 	'content'    => '<!-- wp:group {"align":"full","layout":{"inherit":true}} -->
-				<div class="wp-block-group alignfull"><!-- wp:spacer -->
+				<div class="wp-block-group alignfull"><!-- wp:spacer {"height":100} -->
 				<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
@@ -33,7 +33,7 @@ return array(
 				<!-- /wp:column --></div>
 				<!-- /wp:columns -->
 
-				<!-- wp:spacer {"height":"70px"} -->
+				<!-- wp:spacer {"height":70} -->
 				<div style="height:70px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer --></div>
 				<!-- /wp:group -->',

--- a/frost/inc/patterns/featured-boxes/featured-boxes-three-black-background.php
+++ b/frost/inc/patterns/featured-boxes/featured-boxes-three-black-background.php
@@ -9,7 +9,7 @@ return array(
 	'title'      => __( 'Featured boxes with text, button.', 'frost' ),
 	'categories' => array( 'frost-featured-boxes' ),
 	'content'    => '<!-- wp:group {"align":"full","backgroundColor":"black","layout":{"inherit":true}} -->
-				<div class="wp-block-group alignfull has-black-background-color has-background"><!-- wp:spacer -->
+				<div class="wp-block-group alignfull has-black-background-color has-background"><!-- wp:spacer {"height":100} -->
 				<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
@@ -63,7 +63,7 @@ return array(
 				<!-- /wp:column --></div>
 				<!-- /wp:columns -->
 
-				<!-- wp:spacer {"height":"70px"} -->
+				<!-- wp:spacer {"height":70} -->
 				<div style="height:70px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer --></div>
 				<!-- /wp:group -->',

--- a/frost/inc/patterns/featured-boxes/featured-boxes-three.php
+++ b/frost/inc/patterns/featured-boxes/featured-boxes-three.php
@@ -9,7 +9,7 @@ return array(
 	'title'      => __( 'Featured boxes with text, button.', 'frost' ),
 	'categories' => array( 'frost-featured-boxes' ),
 	'content'    => '<!-- wp:group {"align":"full","textColor":"white","layout":{"inherit":true}} -->
-				<div class="wp-block-group alignfull has-white-color has-text-color"><!-- wp:spacer -->
+				<div class="wp-block-group alignfull has-white-color has-text-color"><!-- wp:spacer {"height":100} -->
 				<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
@@ -63,7 +63,7 @@ return array(
 				<!-- /wp:column --></div>
 				<!-- /wp:columns -->
 
-				<!-- wp:spacer {"height":"70px"} -->
+				<!-- wp:spacer {"height":70} -->
 				<div style="height:70px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer --></div>
 				<!-- /wp:group -->',

--- a/frost/inc/patterns/featured-boxes/featured-boxes-two-black-background.php
+++ b/frost/inc/patterns/featured-boxes/featured-boxes-two-black-background.php
@@ -9,7 +9,7 @@ return array(
 	'title'      => __( 'Featured boxes with text, button.', 'frost' ),
 	'categories' => array( 'frost-featured-boxes' ),
 	'content'    => '<!-- wp:group {"align":"full","backgroundColor":"black","layout":{"inherit":true}} -->
-				<div class="wp-block-group alignfull has-black-background-color has-background"><!-- wp:spacer -->
+				<div class="wp-block-group alignfull has-black-background-color has-background"><!-- wp:spacer {"height":100} -->
 				<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
@@ -47,7 +47,7 @@ return array(
 				<!-- /wp:column --></div>
 				<!-- /wp:columns -->
 
-				<!-- wp:spacer {"height":"70px"} -->
+				<!-- wp:spacer {"height":70} -->
 				<div style="height:70px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer --></div>
 				<!-- /wp:group -->',

--- a/frost/inc/patterns/featured-boxes/featured-boxes-two.php
+++ b/frost/inc/patterns/featured-boxes/featured-boxes-two.php
@@ -9,7 +9,7 @@ return array(
 	'title'      => __( 'Featured boxes with text, button.', 'frost' ),
 	'categories' => array( 'frost-featured-boxes' ),
 	'content'    => '<!-- wp:group {"align":"full","textColor":"white","layout":{"inherit":true}} -->
-				<div class="wp-block-group alignfull has-white-color has-text-color"><!-- wp:spacer -->
+				<div class="wp-block-group alignfull has-white-color has-text-color"><!-- wp:spacer {"height":100} -->
 				<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
@@ -47,7 +47,7 @@ return array(
 				<!-- /wp:column --></div>
 				<!-- /wp:columns -->
 
-				<!-- wp:spacer {"height":"70px"} -->
+				<!-- wp:spacer {"height":70} -->
 				<div style="height:70px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer --></div>
 				<!-- /wp:group -->',

--- a/frost/inc/patterns/footer/footer-stacked-black-background.php
+++ b/frost/inc/patterns/footer/footer-stacked-black-background.php
@@ -24,7 +24,7 @@ return array(
 				<!-- /wp:button --></div>
 				<!-- /wp:buttons -->
 
-				<!-- wp:spacer {"height":"70px"} -->
+				<!-- wp:spacer {"height":70} -->
 				<div style="height:70px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 

--- a/frost/inc/patterns/footer/footer-stacked.php
+++ b/frost/inc/patterns/footer/footer-stacked.php
@@ -24,7 +24,7 @@ return array(
 				<!-- /wp:button --></div>
 				<!-- /wp:buttons -->
 
-				<!-- wp:spacer {"height":"70px"} -->
+				<!-- wp:spacer {"height":70} -->
 				<div style="height:70px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 

--- a/frost/inc/patterns/hero-section/hero-section-one-column-black-background.php
+++ b/frost/inc/patterns/hero-section/hero-section-one-column-black-background.php
@@ -9,7 +9,7 @@ return array(
 	'title'      => __( 'Section with image, text, buttons.', 'frost' ),
 	'categories' => array( 'frost-hero-section' ),
 	'content'    => '<!-- wp:group {"align":"full","backgroundColor":"black","textColor":"white","layout":{"wideSize":"800px"}} -->
-				<div class="wp-block-group alignfull has-white-color has-black-background-color has-text-color has-background"><!-- wp:spacer -->
+				<div class="wp-block-group alignfull has-white-color has-black-background-color has-text-color has-background"><!-- wp:spacer {"height":100} -->
 				<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
@@ -17,7 +17,7 @@ return array(
 				<figure class="wp-block-image size-full"><img src="' . esc_url( __( 'https://frostwp.com/wp-content/uploads/2021/12/sample-white_1920x1200.jpg', 'frost' ) ) . '"  alt="' . esc_attr__( 'Sample Image', 'frost' ) . '" class="wp-image-3482"/></figure>
 				<!-- /wp:image -->
 
-				<!-- wp:spacer {"height":"30px"} -->
+				<!-- wp:spacer {"height":30} -->
 				<div style="height:30px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
@@ -39,7 +39,7 @@ return array(
 				<!-- /wp:button --></div>
 				<!-- /wp:buttons -->
 
-				<!-- wp:spacer -->
+				<!-- wp:spacer {"height":100} -->
 				<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer --></div>
 				<!-- /wp:group -->',

--- a/frost/inc/patterns/hero-section/hero-section-one-column.php
+++ b/frost/inc/patterns/hero-section/hero-section-one-column.php
@@ -9,7 +9,7 @@ return array(
 	'title'      => __( 'Section with image, text, buttons.', 'frost' ),
 	'categories' => array( 'frost-hero-section' ),
 	'content'    => '<!-- wp:group {"align":"full","layout":{"wideSize":"800px"}} -->
-				<div class="wp-block-group alignfull"><!-- wp:spacer -->
+				<div class="wp-block-group alignfull"><!-- wp:spacer {"height":100} -->
 				<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
@@ -17,7 +17,7 @@ return array(
 				<figure class="wp-block-image size-full"><img src="' . esc_url( __( 'https://frostwp.com/wp-content/uploads/2021/12/sample-black_1920x1200.jpg', 'frost' ) ) . '"  alt="' . esc_attr__( 'Sample Image', 'frost' ) . '" class="wp-image-3480"/></figure>
 				<!-- /wp:image -->
 
-				<!-- wp:spacer {"height":"30px"} -->
+				<!-- wp:spacer {"height":30} -->
 				<div style="height:30px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
@@ -39,7 +39,7 @@ return array(
 				<!-- /wp:button --></div>
 				<!-- /wp:buttons -->
 
-				<!-- wp:spacer -->
+				<!-- wp:spacer {"height":100} -->
 				<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer --></div>
 				<!-- /wp:group -->',

--- a/frost/inc/patterns/hero-section/hero-section-three-columns-black-background.php
+++ b/frost/inc/patterns/hero-section/hero-section-three-columns-black-background.php
@@ -9,7 +9,7 @@ return array(
 	'title'      => __( 'Section with image, text, button.', 'frost' ),
 	'categories' => array( 'frost-hero-section' ),
 	'content'    => '<!-- wp:group {"align":"full","backgroundColor":"black","textColor":"white","layout":{"inherit":true}} -->
-				<div class="wp-block-group alignfull has-white-color has-black-background-color has-text-color has-background"><!-- wp:spacer -->
+				<div class="wp-block-group alignfull has-white-color has-black-background-color has-text-color has-background"><!-- wp:spacer {"height":100} -->
 				<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
@@ -21,7 +21,7 @@ return array(
 				<p class="has-text-align-center is-style-no-margin">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
 				<!-- /wp:paragraph -->
 
-				<!-- wp:spacer {"height":"40px"} -->
+				<!-- wp:spacer {"height":40} -->
 				<div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
@@ -87,7 +87,7 @@ return array(
 				<!-- /wp:column --></div>
 				<!-- /wp:columns -->
 
-				<!-- wp:spacer {"height":"70px"} -->
+				<!-- wp:spacer {"height":70} -->
 				<div style="height:70px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer --></div>
 				<!-- /wp:group -->',

--- a/frost/inc/patterns/hero-section/hero-section-three-columns.php
+++ b/frost/inc/patterns/hero-section/hero-section-three-columns.php
@@ -9,7 +9,7 @@ return array(
 	'title'      => __( 'Section with image, text, button.', 'frost' ),
 	'categories' => array( 'frost-hero-section' ),
 	'content'    => '<!-- wp:group {"align":"full","layout":{"inherit":true}} -->
-				<div class="wp-block-group alignfull"><!-- wp:spacer -->
+				<div class="wp-block-group alignfull"><!-- wp:spacer {"height":100} -->
 				<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
@@ -21,7 +21,7 @@ return array(
 				<p class="has-text-align-center is-style-no-margin">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
 				<!-- /wp:paragraph -->
 
-				<!-- wp:spacer {"height":"40px"} -->
+				<!-- wp:spacer {"height":40} -->
 				<div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
@@ -87,7 +87,7 @@ return array(
 				<!-- /wp:column --></div>
 				<!-- /wp:columns -->
 
-				<!-- wp:spacer {"height":"70px"} -->
+				<!-- wp:spacer {"height":70} -->
 				<div style="height:70px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer --></div>
 				<!-- /wp:group -->',

--- a/frost/inc/patterns/hero-section/hero-section-two-columns-black-background.php
+++ b/frost/inc/patterns/hero-section/hero-section-two-columns-black-background.php
@@ -9,7 +9,7 @@ return array(
 	'title'      => __( 'Section with media, text, buttons.', 'frost' ),
 	'categories' => array( 'frost-hero-section' ),
 	'content'    => '<!-- wp:group {"align":"full","backgroundColor":"black","textColor":"white","layout":{"inherit":true}} -->
-				<div class="wp-block-group alignfull has-white-color has-black-background-color has-text-color has-background"><!-- wp:spacer -->
+				<div class="wp-block-group alignfull has-white-color has-black-background-color has-text-color has-background"><!-- wp:spacer {"height":100} -->
 				<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
@@ -33,7 +33,7 @@ return array(
 				<!-- /wp:buttons --></div></div>
 				<!-- /wp:media-text -->
 
-				<!-- wp:spacer -->
+				<!-- wp:spacer {"height":100} -->
 				<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer --></div>
 				<!-- /wp:group -->',

--- a/frost/inc/patterns/hero-section/hero-section-two-columns.php
+++ b/frost/inc/patterns/hero-section/hero-section-two-columns.php
@@ -9,7 +9,7 @@ return array(
 	'title'      => __( 'Section with media, text, buttons.', 'frost' ),
 	'categories' => array( 'frost-hero-section' ),
 	'content'    => '<!-- wp:group {"align":"full","layout":{"inherit":true}} -->
-				<div class="wp-block-group alignfull"><!-- wp:spacer -->
+				<div class="wp-block-group alignfull"><!-- wp:spacer {"height":100} -->
 				<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
@@ -33,7 +33,7 @@ return array(
 				<!-- /wp:buttons --></div></div>
 				<!-- /wp:media-text -->
 
-				<!-- wp:spacer -->
+				<!-- wp:spacer {"height":100} -->
 				<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer --></div>
 				<!-- /wp:group -->',

--- a/frost/inc/patterns/page/page-home.php
+++ b/frost/inc/patterns/page/page-home.php
@@ -9,7 +9,7 @@ return array(
 	'title'      => __( 'Sample home page.', 'frost' ),
 	'categories' => array( 'frost-page' ),
 	'content'    => '<!-- wp:group {"align":"full","layout":{"wideSize":"800px"}} -->
-				<div class="wp-block-group alignfull"><!-- wp:spacer {"height":"70px"} -->
+				<div class="wp-block-group alignfull"><!-- wp:spacer {"height":70} -->
 				<div style="height:70px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
@@ -17,7 +17,7 @@ return array(
 				<figure class="wp-block-image size-full"><img src="' . esc_url( __( 'https://frostwp.com/wp-content/uploads/2021/12/sample-black_1920x1200.jpg', 'frost' ) ) . '"  alt="' . esc_attr__( 'Sample Image', 'frost' ) . '" class="wp-image-3480"/></figure>
 				<!-- /wp:image -->
 
-				<!-- wp:spacer {"height":"30px"} -->
+				<!-- wp:spacer {"height":30} -->
 				<div style="height:30px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
@@ -39,13 +39,13 @@ return array(
 				<!-- /wp:button --></div>
 				<!-- /wp:buttons -->
 
-				<!-- wp:spacer -->
+				<!-- wp:spacer {"height":100} -->
 				<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer --></div>
 				<!-- /wp:group -->
 
 				<!-- wp:group {"align":"full","backgroundColor":"black","textColor":"white","layout":{"inherit":true}} -->
-				<div class="wp-block-group alignfull has-white-color has-black-background-color has-text-color has-background"><!-- wp:spacer -->
+				<div class="wp-block-group alignfull has-white-color has-black-background-color has-text-color has-background"><!-- wp:spacer {"height":100} -->
 				<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
@@ -69,13 +69,13 @@ return array(
 				<!-- /wp:buttons --></div></div>
 				<!-- /wp:media-text -->
 
-				<!-- wp:spacer -->
+				<!-- wp:spacer {"height":100} -->
 				<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer --></div>
 				<!-- /wp:group -->
 
 				<!-- wp:group {"align":"full","layout":{"inherit":true}} -->
-				<div class="wp-block-group alignfull"><!-- wp:spacer -->
+				<div class="wp-block-group alignfull"><!-- wp:spacer {"height":100} -->
 				<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
@@ -99,13 +99,13 @@ return array(
 				<!-- /wp:buttons --></div></div>
 				<!-- /wp:media-text -->
 
-				<!-- wp:spacer -->
+				<!-- wp:spacer {"height":100} -->
 				<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer --></div>
 				<!-- /wp:group -->
 
 				<!-- wp:group {"align":"full","backgroundColor":"black","textColor":"white","layout":{"inherit":true}} -->
-				<div class="wp-block-group alignfull has-white-color has-black-background-color has-text-color has-background"><!-- wp:spacer -->
+				<div class="wp-block-group alignfull has-white-color has-black-background-color has-text-color has-background"><!-- wp:spacer {"height":100} -->
 				<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
@@ -125,13 +125,13 @@ return array(
 				<!-- /wp:column --></div>
 				<!-- /wp:columns -->
 
-				<!-- wp:spacer {"height":"70px"} -->
+				<!-- wp:spacer {"height":70} -->
 				<div style="height:70px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer --></div>
 				<!-- /wp:group -->
 
 				<!-- wp:group {"align":"full","layout":{"inherit":true}} -->
-				<div class="wp-block-group alignfull"><!-- wp:spacer -->
+				<div class="wp-block-group alignfull"><!-- wp:spacer {"height":100} -->
 				<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
@@ -143,7 +143,7 @@ return array(
 				<p class="has-text-align-center is-style-no-margin">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p>
 				<!-- /wp:paragraph -->
 
-				<!-- wp:spacer {"height":"40px"} -->
+				<!-- wp:spacer {"height":40} -->
 				<div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
@@ -209,7 +209,7 @@ return array(
 				<!-- /wp:column --></div>
 				<!-- /wp:columns -->
 
-				<!-- wp:spacer {"height":"70px"} -->
+				<!-- wp:spacer {"height":70} -->
 				<div style="height:70px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer --></div>
 				<!-- /wp:group -->',

--- a/frost/inc/patterns/page/page-link-black-background.php
+++ b/frost/inc/patterns/page/page-link-black-background.php
@@ -10,69 +10,69 @@ return array(
 	'categories' => array( 'frost-page' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|white"}}}},"backgroundColor":"black","textColor":"white","className":"is-style-full-height","layout":{"inherit":true}} -->
 				<div class="wp-block-group alignfull is-style-full-height has-white-color has-black-background-color has-text-color has-background has-link-color"><!-- wp:group -->
-				<div class="wp-block-group"><!-- wp:spacer -->
+				<div class="wp-block-group"><!-- wp:spacer {"height":100} -->
 				<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
-				
+
 				<!-- wp:image {"align":"center","id":3488,"width":120,"height":120,"sizeSlug":"full","linkDestination":"none","className":"is-style-rounded"} -->
 				<div class="wp-block-image is-style-rounded"><figure class="aligncenter size-full is-resized"><img src="' . esc_url( __( 'https://frostwp.com/wp-content/uploads/2021/12/sample-white_800x800.jpg', 'frost' ) ) . '"  alt="' . esc_attr__( 'Sample Image', 'frost' ) . '" class="wp-image-3488" width="120" height="120"/></figure></div>
 				<!-- /wp:image -->
-				
+
 				<!-- wp:heading {"textAlign":"center","fontSize":"x-large"} -->
 				<h2 class="has-text-align-center has-x-large-font-size" id="your-name">' . esc_html__( 'Your Name', 'frost' ) . '</h2>
 				<!-- /wp:heading -->
-				
+
 				<!-- wp:paragraph {"align":"center"} -->
 				<p class="has-text-align-center">' . esc_html__( 'Company Name', 'frost' ) . '<br><a href="mailto:name@company.com">name@company.com</a></p>
 				<!-- /wp:paragraph -->
-				
+
 				<!-- wp:social-links {"iconColor":"black","iconColorValue":"#000","iconBackgroundColor":"white","iconBackgroundColorValue":"#fff","size":"has-normal-icon-size","align":"center"} -->
 				<ul class="wp-block-social-links aligncenter has-normal-icon-size has-icon-color has-icon-background-color"><!-- wp:social-link {"url":"#","service":"facebook"} /-->
-				
+
 				<!-- wp:social-link {"url":"#","service":"instagram"} /-->
-				
+
 				<!-- wp:social-link {"url":"#","service":"twitter"} /-->
-				
+
 				<!-- wp:social-link {"url":"#","service":"dribbble"} /-->
-				
+
 				<!-- wp:social-link {"url":"#","service":"linkedin"} /--></ul>
 				<!-- /wp:social-links -->
-				
-				<!-- wp:spacer {"height":"60px"} -->
+
+				<!-- wp:spacer {"height":60} -->
 				<div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
-				
+
 				<!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center","orientation":"horizontal"}} -->
 				<div class="wp-block-buttons"><!-- wp:button {"width":100,"style":{"border":{"radius":0}},"className":"is-style-fill-white"} -->
 				<div class="wp-block-button has-custom-width wp-block-button__width-100 is-style-fill-white"><a class="wp-block-button__link no-border-radius">' . esc_html__( 'Visit My Website', 'frost' ) . '</a></div>
 				<!-- /wp:button -->
-				
+
 				<!-- wp:button {"width":100,"style":{"border":{"radius":0}},"className":"is-style-fill-white"} -->
 				<div class="wp-block-button has-custom-width wp-block-button__width-100 is-style-fill-white"><a class="wp-block-button__link no-border-radius">' . esc_html__( 'Read My Blog', 'frost' ) . '</a></div>
 				<!-- /wp:button -->
-				
+
 				<!-- wp:button {"width":100,"style":{"border":{"radius":0}},"className":"is-style-fill-white"} -->
 				<div class="wp-block-button has-custom-width wp-block-button__width-100 is-style-fill-white"><a class="wp-block-button__link no-border-radius">' . esc_html__( 'Download My Ebook', 'frost' ) . '</a></div>
 				<!-- /wp:button -->
-				
+
 				<!-- wp:button {"width":100,"style":{"border":{"radius":0}},"className":"is-style-fill-white"} -->
 				<div class="wp-block-button has-custom-width wp-block-button__width-100 is-style-fill-white"><a class="wp-block-button__link no-border-radius">' . esc_html__( 'Follow My Newsletter', 'frost' ) . '</a></div>
 				<!-- /wp:button -->
-				
+
 				<!-- wp:button {"width":100,"style":{"border":{"radius":0}},"className":"is-style-fill-white"} -->
 				<div class="wp-block-button has-custom-width wp-block-button__width-100 is-style-fill-white"><a class="wp-block-button__link no-border-radius">' . esc_html__( 'Listen to My Podcast', 'frost' ) . '</a></div>
 				<!-- /wp:button --></div>
 				<!-- /wp:buttons -->
-				
-				<!-- wp:spacer {"height":"40px"} -->
+
+				<!-- wp:spacer {"height":40} -->
 				<div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
-				
+
 				<!-- wp:paragraph {"align":"center"} -->
 				<p class="has-text-align-center"><a href="https://frostwp.com/">' . esc_html__( 'Made with Frost', 'frost' ) . '</a></p>
 				<!-- /wp:paragraph -->
-				
-				<!-- wp:spacer {"height":"70px"} -->
+
+				<!-- wp:spacer {"height":70} -->
 				<div style="height:70px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer --></div>
 				<!-- /wp:group --></div>

--- a/frost/inc/patterns/page/page-link.php
+++ b/frost/inc/patterns/page/page-link.php
@@ -10,7 +10,7 @@ return array(
 	'categories' => array( 'frost-page' ),
 	'content'    => '<!-- wp:group {"align":"full","className":"is-style-full-height","layout":{"inherit":true}} -->
 				<div class="wp-block-group alignfull is-style-full-height"><!-- wp:group -->
-				<div class="wp-block-group"><!-- wp:spacer -->
+				<div class="wp-block-group"><!-- wp:spacer {"height":100} -->
 				<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
@@ -38,7 +38,7 @@ return array(
 				<!-- wp:social-link {"url":"#","service":"linkedin"} /--></ul>
 				<!-- /wp:social-links -->
 
-				<!-- wp:spacer {"height":"60px"} -->
+				<!-- wp:spacer {"height":60} -->
 				<div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
@@ -64,7 +64,7 @@ return array(
 				<!-- /wp:button --></div>
 				<!-- /wp:buttons -->
 
-				<!-- wp:spacer {"height":"40px"} -->
+				<!-- wp:spacer {"height":40} -->
 				<div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
@@ -72,7 +72,7 @@ return array(
 				<p class="has-text-align-center"><a href="https://frostwp.com/">' . esc_html__( 'Made with Frost', 'frost' ) . '</a></p>
 				<!-- /wp:paragraph -->
 
-				<!-- wp:spacer {"height":"70px"} -->
+				<!-- wp:spacer {"height":70} -->
 				<div style="height:70px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer --></div>
 				<!-- /wp:group --></div>

--- a/frost/inc/patterns/podcast-episode/podcast-episode-black-background.php
+++ b/frost/inc/patterns/podcast-episode/podcast-episode-black-background.php
@@ -9,7 +9,7 @@ return array(
 	'title'      => __( 'Podcast episode with media, text.', 'frost' ),
 	'categories' => array( 'frost-podcast-episode' ),
 	'content'    => '<!-- wp:group {"align":"full","backgroundColor":"black","textColor":"white","layout":{"inherit":true}} -->
-				<div class="wp-block-group alignfull has-white-color has-black-background-color has-text-color has-background"><!-- wp:spacer -->
+				<div class="wp-block-group alignfull has-white-color has-black-background-color has-text-color has-background"><!-- wp:spacer {"height":100} -->
 				<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
@@ -53,7 +53,7 @@ return array(
 				<!-- /wp:column --></div>
 				<!-- /wp:columns -->
 
-				<!-- wp:spacer {"height":"70px"} -->
+				<!-- wp:spacer {"height":70} -->
 				<div style="height:70px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer --></div>
 				<!-- /wp:group -->',

--- a/frost/inc/patterns/podcast-episode/podcast-episode.php
+++ b/frost/inc/patterns/podcast-episode/podcast-episode.php
@@ -9,7 +9,7 @@ return array(
 	'title'      => __( 'Podcast episode with media, text.', 'frost' ),
 	'categories' => array( 'frost-podcast-episode' ),
 	'content'    => '<!-- wp:group {"align":"full","layout":{"inherit":true}} -->
-				<div class="wp-block-group alignfull"><!-- wp:spacer -->
+				<div class="wp-block-group alignfull"><!-- wp:spacer {"height":100} -->
 				<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
@@ -53,7 +53,7 @@ return array(
 				<!-- /wp:column --></div>
 				<!-- /wp:columns -->
 
-				<!-- wp:spacer {"height":"70px"} -->
+				<!-- wp:spacer {"height":70} -->
 				<div style="height:70px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer --></div>
 				<!-- /wp:group -->',

--- a/frost/inc/patterns/portfolio/portfolio-black-background.php
+++ b/frost/inc/patterns/portfolio/portfolio-black-background.php
@@ -9,7 +9,7 @@ return array(
 	'title'      => __( 'Portfolio with images, text.', 'frost' ),
 	'categories' => array( 'frost-portfolio' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|white"}}}},"backgroundColor":"black","textColor":"white","layout":{"inherit":true}} -->
-				<div class="wp-block-group alignfull has-white-color has-black-background-color has-text-color has-background has-link-color"><!-- wp:spacer -->
+				<div class="wp-block-group alignfull has-white-color has-black-background-color has-text-color has-background has-link-color"><!-- wp:spacer {"height":100} -->
 				<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
@@ -49,7 +49,7 @@ return array(
 				<!-- /wp:column --></div>
 				<!-- /wp:columns -->
 
-				<!-- wp:spacer {"height":"30px"} -->
+				<!-- wp:spacer {"height":30} -->
 				<div style="height:30px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer --></div>
 				<!-- /wp:group -->',

--- a/frost/inc/patterns/portfolio/portfolio.php
+++ b/frost/inc/patterns/portfolio/portfolio.php
@@ -9,7 +9,7 @@ return array(
 	'title'      => __( 'Portfolio with images, text.', 'frost' ),
 	'categories' => array( 'frost-portfolio' ),
 	'content'    => '<!-- wp:group {"align":"full","layout":{"inherit":true}} -->
-				<div class="wp-block-group alignfull"><!-- wp:spacer -->
+				<div class="wp-block-group alignfull"><!-- wp:spacer {"height":100} -->
 				<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
@@ -49,7 +49,7 @@ return array(
 				<!-- /wp:column --></div>
 				<!-- /wp:columns -->
 
-				<!-- wp:spacer {"height":"30px"} -->
+				<!-- wp:spacer {"height":30} -->
 				<div style="height:30px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer --></div>
 				<!-- /wp:group -->',

--- a/frost/inc/patterns/pricing-table/pricing-table-four-columns-black-background.php
+++ b/frost/inc/patterns/pricing-table/pricing-table-four-columns-black-background.php
@@ -9,7 +9,7 @@ return array(
 	'title'      => __( 'Pricing table with list, buttons.', 'frost' ),
 	'categories' => array( 'frost-pricing-table' ),
 	'content'    => '<!-- wp:group {"align":"full","backgroundColor":"black","textColor":"white","layout":{"inherit":true}} -->
-				<div class="wp-block-group alignfull has-white-color has-black-background-color has-text-color has-background"><!-- wp:spacer -->
+				<div class="wp-block-group alignfull has-white-color has-black-background-color has-text-color has-background"><!-- wp:spacer {"height":100} -->
 				<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
@@ -38,7 +38,7 @@ return array(
 				<li>' . esc_html__( 'Feature Item', 'frost' ) . '</li></ul>
 				<!-- /wp:list -->
 
-				<!-- wp:spacer {"height":"30px"} -->
+				<!-- wp:spacer {"height":30} -->
 				<div style="height:30px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
@@ -67,7 +67,7 @@ return array(
 				<li>' . esc_html__( 'Feature Item', 'frost' ) . '</li></ul>
 				<!-- /wp:list -->
 
-				<!-- wp:spacer {"height":"30px"} -->
+				<!-- wp:spacer {"height":30} -->
 				<div style="height:30px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
@@ -96,7 +96,7 @@ return array(
 				<li>' . esc_html__( 'Feature Item', 'frost' ) . '</li></ul>
 				<!-- /wp:list -->
 
-				<!-- wp:spacer {"height":"30px"} -->
+				<!-- wp:spacer {"height":30} -->
 				<div style="height:30px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
@@ -125,7 +125,7 @@ return array(
 				<li>' . esc_html__( 'Feature Item', 'frost' ) . '</li></ul>
 				<!-- /wp:list -->
 
-				<!-- wp:spacer {"height":"30px"} -->
+				<!-- wp:spacer {"height":30} -->
 				<div style="height:30px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
@@ -139,7 +139,7 @@ return array(
 				<!-- /wp:column --></div>
 				<!-- /wp:columns -->
 
-				<!-- wp:spacer {"height":"70px"} -->
+				<!-- wp:spacer {"height":70} -->
 				<div style="height:70px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer --></div>
 				<!-- /wp:group -->',

--- a/frost/inc/patterns/pricing-table/pricing-table-four-columns.php
+++ b/frost/inc/patterns/pricing-table/pricing-table-four-columns.php
@@ -9,7 +9,7 @@ return array(
 	'title'      => __( 'Pricing table with list, buttons.', 'frost' ),
 	'categories' => array( 'frost-pricing-table' ),
 	'content'    => '<!-- wp:group {"align":"full","layout":{"inherit":true}} -->
-				<div class="wp-block-group alignfull"><!-- wp:spacer -->
+				<div class="wp-block-group alignfull"><!-- wp:spacer {"height":100} -->
 				<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
@@ -38,7 +38,7 @@ return array(
 				<li>' . esc_html__( 'Feature Item', 'frost' ) . '</li></ul>
 				<!-- /wp:list -->
 
-				<!-- wp:spacer {"height":"30px"} -->
+				<!-- wp:spacer {"height":30} -->
 				<div style="height:30px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
@@ -67,7 +67,7 @@ return array(
 				<li>' . esc_html__( 'Feature Item', 'frost' ) . '</li></ul>
 				<!-- /wp:list -->
 
-				<!-- wp:spacer {"height":"30px"} -->
+				<!-- wp:spacer {"height":30} -->
 				<div style="height:30px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
@@ -96,7 +96,7 @@ return array(
 				<li>' . esc_html__( 'Feature Item', 'frost' ) . '</li></ul>
 				<!-- /wp:list -->
 
-				<!-- wp:spacer {"height":"30px"} -->
+				<!-- wp:spacer {"height":30} -->
 				<div style="height:30px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
@@ -125,7 +125,7 @@ return array(
 				<li>' . esc_html__( 'Feature Item', 'frost' ) . '</li></ul>
 				<!-- /wp:list -->
 
-				<!-- wp:spacer {"height":"30px"} -->
+				<!-- wp:spacer {"height":30} -->
 				<div style="height:30px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
@@ -139,7 +139,7 @@ return array(
 				<!-- /wp:column --></div>
 				<!-- /wp:columns -->
 
-				<!-- wp:spacer {"height":"70px"} -->
+				<!-- wp:spacer {"height":70} -->
 				<div style="height:70px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer --></div>
 				<!-- /wp:group -->',

--- a/frost/inc/patterns/pricing-table/pricing-table-three-columns-black-background.php
+++ b/frost/inc/patterns/pricing-table/pricing-table-three-columns-black-background.php
@@ -9,7 +9,7 @@ return array(
 	'title'      => __( 'Pricing table with list, buttons.', 'frost' ),
 	'categories' => array( 'frost-pricing-table' ),
 	'content'    => '<!-- wp:group {"align":"full","backgroundColor":"black","textColor":"white","layout":{"inherit":true}} -->
-				<div class="wp-block-group alignfull has-white-color has-black-background-color has-text-color has-background"><!-- wp:spacer -->
+				<div class="wp-block-group alignfull has-white-color has-black-background-color has-text-color has-background"><!-- wp:spacer {"height":100} -->
 				<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
@@ -38,7 +38,7 @@ return array(
 				<li>' . esc_html__( 'Feature Item', 'frost' ) . '</li></ul>
 				<!-- /wp:list -->
 
-				<!-- wp:spacer {"height":"30px"} -->
+				<!-- wp:spacer {"height":30} -->
 				<div style="height:30px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
@@ -67,7 +67,7 @@ return array(
 				<li>' . esc_html__( 'Feature Item', 'frost' ) . '</li></ul>
 				<!-- /wp:list -->
 
-				<!-- wp:spacer {"height":"30px"} -->
+				<!-- wp:spacer {"height":30} -->
 				<div style="height:30px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
@@ -96,7 +96,7 @@ return array(
 				<li>' . esc_html__( 'Feature Item', 'frost' ) . '</li></ul>
 				<!-- /wp:list -->
 
-				<!-- wp:spacer {"height":"30px"} -->
+				<!-- wp:spacer {"height":30} -->
 				<div style="height:30px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
@@ -110,7 +110,7 @@ return array(
 				<!-- /wp:column --></div>
 				<!-- /wp:columns -->
 
-				<!-- wp:spacer {"height":"70px"} -->
+				<!-- wp:spacer {"height":70} -->
 				<div style="height:70px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer --></div>
 				<!-- /wp:group -->',

--- a/frost/inc/patterns/pricing-table/pricing-table-three-columns.php
+++ b/frost/inc/patterns/pricing-table/pricing-table-three-columns.php
@@ -9,7 +9,7 @@ return array(
 	'title'      => __( 'Pricing table with list, buttons.', 'frost' ),
 	'categories' => array( 'frost-pricing-table' ),
 	'content'    => '<!-- wp:group {"align":"full","layout":{"inherit":true}} -->
-				<div class="wp-block-group alignfull"><!-- wp:spacer -->
+				<div class="wp-block-group alignfull"><!-- wp:spacer {"height":100} -->
 				<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
@@ -38,7 +38,7 @@ return array(
 				<li>' . esc_html__( 'Feature Item', 'frost' ) . '</li></ul>
 				<!-- /wp:list -->
 
-				<!-- wp:spacer {"height":"30px"} -->
+				<!-- wp:spacer {"height":30} -->
 				<div style="height:30px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
@@ -67,7 +67,7 @@ return array(
 				<li>' . esc_html__( 'Feature Item', 'frost' ) . '</li></ul>
 				<!-- /wp:list -->
 
-				<!-- wp:spacer {"height":"30px"} -->
+				<!-- wp:spacer {"height":30} -->
 				<div style="height:30px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
@@ -96,7 +96,7 @@ return array(
 				<li>' . esc_html__( 'Feature Item', 'frost' ) . '</li></ul>
 				<!-- /wp:list -->
 
-				<!-- wp:spacer {"height":"30px"} -->
+				<!-- wp:spacer {"height":30} -->
 				<div style="height:30px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
@@ -110,7 +110,7 @@ return array(
 				<!-- /wp:column --></div>
 				<!-- /wp:columns -->
 
-				<!-- wp:spacer {"height":"70px"} -->
+				<!-- wp:spacer {"height":70} -->
 				<div style="height:70px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer --></div>
 				<!-- /wp:group -->',

--- a/frost/inc/patterns/pricing-table/pricing-table-two-columns-black-background.php
+++ b/frost/inc/patterns/pricing-table/pricing-table-two-columns-black-background.php
@@ -9,7 +9,7 @@ return array(
 	'title'      => __( 'Pricing table with list, buttons.', 'frost' ),
 	'categories' => array( 'frost-pricing-table' ),
 	'content'    => '<!-- wp:group {"align":"full","backgroundColor":"black","textColor":"white","layout":{"wideSize":"800px"}} -->
-				<div class="wp-block-group alignfull has-white-color has-black-background-color has-text-color has-background"><!-- wp:spacer -->
+				<div class="wp-block-group alignfull has-white-color has-black-background-color has-text-color has-background"><!-- wp:spacer {"height":100} -->
 				<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
@@ -38,7 +38,7 @@ return array(
 				<li>' . esc_html__( 'Feature Item', 'frost' ) . '</li></ul>
 				<!-- /wp:list -->
 
-				<!-- wp:spacer {"height":"30px"} -->
+				<!-- wp:spacer {"height":30} -->
 				<div style="height:30px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
@@ -67,7 +67,7 @@ return array(
 				<li>' . esc_html__( 'Feature Item', 'frost' ) . '</li></ul>
 				<!-- /wp:list -->
 
-				<!-- wp:spacer {"height":"30px"} -->
+				<!-- wp:spacer {"height":30} -->
 				<div style="height:30px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
@@ -79,13 +79,13 @@ return array(
 				<!-- /wp:group --></div>
 				<!-- /wp:group -->
 
-				<!-- wp:spacer {"height":"10px"} -->
+				<!-- wp:spacer {"height":10} -->
 				<div style="height:10px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer --></div>
 				<!-- /wp:column --></div>
 				<!-- /wp:columns -->
 
-				<!-- wp:spacer {"height":"70px"} -->
+				<!-- wp:spacer {"height":70} -->
 				<div style="height:70px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer --></div>
 				<!-- /wp:group -->',

--- a/frost/inc/patterns/pricing-table/pricing-table-two-columns.php
+++ b/frost/inc/patterns/pricing-table/pricing-table-two-columns.php
@@ -9,7 +9,7 @@ return array(
 	'title'      => __( 'Pricing table with list, buttons.', 'frost' ),
 	'categories' => array( 'frost-pricing-table' ),
 	'content'    => '<!-- wp:group {"align":"full","layout":{"wideSize":"800px"}} -->
-				<div class="wp-block-group alignfull"><!-- wp:spacer -->
+				<div class="wp-block-group alignfull"><!-- wp:spacer {"height":100} -->
 				<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
@@ -38,7 +38,7 @@ return array(
 				<li>' . esc_html__( 'Feature Item', 'frost' ) . '</li></ul>
 				<!-- /wp:list -->
 
-				<!-- wp:spacer {"height":"30px"} -->
+				<!-- wp:spacer {"height":30} -->
 				<div style="height:30px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
@@ -67,7 +67,7 @@ return array(
 				<li>' . esc_html__( 'Feature Item', 'frost' ) . '</li></ul>
 				<!-- /wp:list -->
 
-				<!-- wp:spacer {"height":"30px"} -->
+				<!-- wp:spacer {"height":30} -->
 				<div style="height:30px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
@@ -81,7 +81,7 @@ return array(
 				<!-- /wp:column --></div>
 				<!-- /wp:columns -->
 
-				<!-- wp:spacer {"height":"70px"} -->
+				<!-- wp:spacer {"height":70} -->
 				<div style="height:70px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer --></div>
 				<!-- /wp:group -->',

--- a/frost/inc/patterns/team-members/team-members-four-columns-black-background.php
+++ b/frost/inc/patterns/team-members/team-members-four-columns-black-background.php
@@ -9,7 +9,7 @@ return array(
 	'title'      => __( 'Team with image, text, link.', 'frost' ),
 	'categories' => array( 'frost-team-members' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|white"}}}},"backgroundColor":"black","textColor":"white","layout":{"inherit":true}} -->
-				<div class="wp-block-group alignfull has-white-color has-black-background-color has-text-color has-background has-link-color"><!-- wp:spacer -->
+				<div class="wp-block-group alignfull has-white-color has-black-background-color has-text-color has-background has-link-color"><!-- wp:spacer {"height":100} -->
 				<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
@@ -21,7 +21,7 @@ return array(
 				<p class="has-text-align-center">' . esc_html__( 'The people who are ready to serve you.', 'frost' ) . '</p>
 				<!-- /wp:paragraph -->
 
-				<!-- wp:spacer {"height":"30px"} -->
+				<!-- wp:spacer {"height":30} -->
 				<div style="height:30px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
@@ -99,7 +99,7 @@ return array(
 				<!-- /wp:column --></div>
 				<!-- /wp:columns -->
 
-				<!-- wp:spacer {"height":"40px"} -->
+				<!-- wp:spacer {"height":40} -->
 				<div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer --></div>
 				<!-- /wp:group -->',

--- a/frost/inc/patterns/team-members/team-members-four-columns.php
+++ b/frost/inc/patterns/team-members/team-members-four-columns.php
@@ -9,7 +9,7 @@ return array(
 	'title'      => __( 'Team with image, text, link.', 'frost' ),
 	'categories' => array( 'frost-team-members' ),
 	'content'    => '<!-- wp:group {"align":"full","layout":{"inherit":true}} -->
-				<div class="wp-block-group alignfull"><!-- wp:spacer -->
+				<div class="wp-block-group alignfull"><!-- wp:spacer {"height":100} -->
 				<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
@@ -21,7 +21,7 @@ return array(
 				<p class="has-text-align-center">' . esc_html__( 'The people who are ready to serve you.', 'frost' ) . '</p>
 				<!-- /wp:paragraph -->
 
-				<!-- wp:spacer {"height":"30px"} -->
+				<!-- wp:spacer {"height":30} -->
 				<div style="height:30px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
@@ -99,7 +99,7 @@ return array(
 				<!-- /wp:column --></div>
 				<!-- /wp:columns -->
 
-				<!-- wp:spacer {"height":"40px"} -->
+				<!-- wp:spacer {"height":40} -->
 				<div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer --></div>
 				<!-- /wp:group -->',

--- a/frost/inc/patterns/team-members/team-members-two-columns-black-background.php
+++ b/frost/inc/patterns/team-members/team-members-two-columns-black-background.php
@@ -9,7 +9,7 @@ return array(
 	'title'      => __( 'Team with image, text, link.', 'frost' ),
 	'categories' => array( 'frost-team-members' ),
 	'content'    => '<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|white"}}}},"backgroundColor":"black","textColor":"white","layout":{"inherit":true}} -->
-				<div class="wp-block-group alignfull has-white-color has-black-background-color has-text-color has-background has-link-color"><!-- wp:spacer -->
+				<div class="wp-block-group alignfull has-white-color has-black-background-color has-text-color has-background has-link-color"><!-- wp:spacer {"height":100} -->
 				<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
@@ -23,7 +23,7 @@ return array(
 				<!-- /wp:paragraph --></div>
 				<!-- /wp:group -->
 
-				<!-- wp:spacer {"height":"30px"} -->
+				<!-- wp:spacer {"height":30} -->
 				<div style="height:30px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
@@ -141,7 +141,7 @@ return array(
 				<!-- /wp:column --></div>
 				<!-- /wp:columns -->
 
-				<!-- wp:spacer {"height":"10px"} -->
+				<!-- wp:spacer {"height":10} -->
 				<div style="height:10px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer --></div>
 				<!-- /wp:group -->',

--- a/frost/inc/patterns/team-members/team-members-two-columns.php
+++ b/frost/inc/patterns/team-members/team-members-two-columns.php
@@ -9,7 +9,7 @@ return array(
 	'title'      => __( 'Team with image, text, link.', 'frost' ),
 	'categories' => array( 'frost-team-members' ),
 	'content'    => '<!-- wp:group {"align":"full","layout":{"inherit":true}} -->
-				<div class="wp-block-group alignfull"><!-- wp:spacer -->
+				<div class="wp-block-group alignfull"><!-- wp:spacer {"height":100} -->
 				<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
@@ -23,7 +23,7 @@ return array(
 				<!-- /wp:paragraph --></div>
 				<!-- /wp:group -->
 
-				<!-- wp:spacer {"height":"30px"} -->
+				<!-- wp:spacer {"height":30} -->
 				<div style="height:30px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
 
@@ -141,7 +141,7 @@ return array(
 				<!-- /wp:column --></div>
 				<!-- /wp:columns -->
 
-				<!-- wp:spacer {"height":"10px"} -->
+				<!-- wp:spacer {"height":10} -->
 				<div style="height:10px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer --></div>
 				<!-- /wp:group -->',

--- a/frost/inc/patterns/testimonials/testimonials-black-background.php
+++ b/frost/inc/patterns/testimonials/testimonials-black-background.php
@@ -9,55 +9,55 @@ return array(
 	'title'      => __( 'Testimonials with text.', 'frost' ),
 	'categories' => array( 'frost-testimonials' ),
 	'content'    => '<!-- wp:group {"align":"full","backgroundColor":"black","textColor":"white","layout":{"inherit":true}} -->
-				<div class="wp-block-group alignfull has-white-color has-black-background-color has-text-color has-background"><!-- wp:spacer -->
+				<div class="wp-block-group alignfull has-white-color has-black-background-color has-text-color has-background"><!-- wp:spacer {"height":100} -->
 				<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
-				
+
 				<!-- wp:columns {"align":"wide"} -->
 				<div class="wp-block-columns alignwide"><!-- wp:column -->
 				<div class="wp-block-column"><!-- wp:heading {"level":4,"style":{"typography":{"fontSize":72,"lineHeight":"1"},"spacing":{"margin":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}}} -->
 				<h4 style="font-size:72px;line-height:1;margin-top:0px;margin-right:0px;margin-bottom:0px;margin-left:0px">“</h4>
 				<!-- /wp:heading -->
-				
+
 				<!-- wp:paragraph {"style":{"typography":{"fontSize":"18px"}}} -->
 				<p style="font-size:18px">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla vitae lorem a neque imperdiet sagittis. Vivamus enim velit.</p>
 				<!-- /wp:paragraph -->
-				
+
 				<!-- wp:paragraph {"fontSize":"small"} -->
 				<p class="has-small-font-size"><strong>—Allison Taylor, Designer</strong></p>
 				<!-- /wp:paragraph --></div>
 				<!-- /wp:column -->
-				
+
 				<!-- wp:column -->
 				<div class="wp-block-column"><!-- wp:heading {"level":4,"style":{"typography":{"fontSize":72,"lineHeight":"1"},"spacing":{"margin":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}}} -->
 				<h4 style="font-size:72px;line-height:1;margin-top:0px;margin-right:0px;margin-bottom:0px;margin-left:0px">“</h4>
 				<!-- /wp:heading -->
-				
+
 				<!-- wp:paragraph {"style":{"typography":{"fontSize":"18px"}}} -->
 				<p style="font-size:18px">Fusce at est sapien. Aliquam tempus et nulla nisipt rhoncus, morbi convallis magna swift. Morbi viverra lobortis ante, volutpat ipsum.</p>
 				<!-- /wp:paragraph -->
-				
+
 				<!-- wp:paragraph {"fontSize":"small"} -->
 				<p class="has-small-font-size"><strong>—Anthony Breck, Developer</strong></p>
 				<!-- /wp:paragraph --></div>
 				<!-- /wp:column -->
-				
+
 				<!-- wp:column -->
 				<div class="wp-block-column"><!-- wp:heading {"level":4,"style":{"typography":{"fontSize":72,"lineHeight":"1"},"spacing":{"margin":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}}} -->
 				<h4 style="font-size:72px;line-height:1;margin-top:0px;margin-right:0px;margin-bottom:0px;margin-left:0px">“</h4>
 				<!-- /wp:heading -->
-				
+
 				<!-- wp:paragraph {"style":{"typography":{"fontSize":"18px"}}} -->
 				<p style="font-size:18px">Quisque ullamcorper nulla breu elementum, atipo consectetur ex iaculis quis. Vestibulum et faucibus. Quisque vitae mi pellentesque.</p>
 				<!-- /wp:paragraph -->
-				
+
 				<!-- wp:paragraph {"fontSize":"small"} -->
 				<p class="has-small-font-size"><strong>—Rebecca Jones, Coach</strong></p>
 				<!-- /wp:paragraph --></div>
 				<!-- /wp:column --></div>
 				<!-- /wp:columns -->
-				
-				<!-- wp:spacer {"height":"40px"} -->
+
+				<!-- wp:spacer {"height":40} -->
 				<div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer --></div>
 				<!-- /wp:group -->',

--- a/frost/inc/patterns/testimonials/testimonials-boxes-black-background.php
+++ b/frost/inc/patterns/testimonials/testimonials-boxes-black-background.php
@@ -9,61 +9,61 @@ return array(
 	'title'      => __( 'Testimonials with text.', 'frost' ),
 	'categories' => array( 'frost-testimonials' ),
 	'content'    => '<!-- wp:group {"align":"full","backgroundColor":"black","layout":{"inherit":true}} -->
-				<div class="wp-block-group alignfull has-black-background-color has-background"><!-- wp:spacer -->
+				<div class="wp-block-group alignfull has-black-background-color has-background"><!-- wp:spacer {"height":100} -->
 				<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
-				
+
 				<!-- wp:columns {"align":"wide"} -->
 				<div class="wp-block-columns alignwide"><!-- wp:column -->
 				<div class="wp-block-column"><!-- wp:group {"style":{"spacing":{"padding":{"top":"30px","right":"30px","bottom":"10px","left":"30px"}}},"backgroundColor":"white"} -->
 				<div class="wp-block-group has-white-background-color has-background" style="padding-top:30px;padding-right:30px;padding-bottom:10px;padding-left:30px"><!-- wp:heading {"textAlign":"center","level":4,"style":{"typography":{"fontSize":72,"lineHeight":"1"},"spacing":{"margin":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}}} -->
 				<h4 class="has-text-align-center" style="font-size:72px;line-height:1;margin-top:0px;margin-right:0px;margin-bottom:0px;margin-left:0px">“</h4>
 				<!-- /wp:heading -->
-				
+
 				<!-- wp:paragraph {"align":"center","style":{"typography":{"fontSize":"18px"}}} -->
 				<p class="has-text-align-center" style="font-size:18px">Lorem ipsum sit amet, consectetur a adipiscing. Nulla vitae lorem a neque imperdiet sagittis vivamus enim velit.</p>
 				<!-- /wp:paragraph -->
-				
+
 				<!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 				<p class="has-text-align-center has-small-font-size"><strong>—Allison Taylor, Designer</strong></p>
 				<!-- /wp:paragraph --></div>
 				<!-- /wp:group --></div>
 				<!-- /wp:column -->
-				
+
 				<!-- wp:column -->
 				<div class="wp-block-column"><!-- wp:group {"style":{"spacing":{"padding":{"top":"30px","right":"30px","bottom":"10px","left":"30px"}}},"backgroundColor":"white"} -->
 				<div class="wp-block-group has-white-background-color has-background" style="padding-top:30px;padding-right:30px;padding-bottom:10px;padding-left:30px"><!-- wp:heading {"textAlign":"center","level":4,"style":{"typography":{"fontSize":72,"lineHeight":"1"},"spacing":{"margin":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}}} -->
 				<h4 class="has-text-align-center" style="font-size:72px;line-height:1;margin-top:0px;margin-right:0px;margin-bottom:0px;margin-left:0px">“</h4>
 				<!-- /wp:heading -->
-				
+
 				<!-- wp:paragraph {"align":"center","style":{"typography":{"fontSize":"18px"}}} -->
 				<p class="has-text-align-center" style="font-size:18px">Fusce at est sapien. Aliquam tempus nulla nisipt rhoncus, morbi et convallis magna rhoncus morbi viverra ante.</p>
 				<!-- /wp:paragraph -->
-				
+
 				<!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 				<p class="has-text-align-center has-small-font-size"><strong>—Anthony Breck, Developer</strong></p>
 				<!-- /wp:paragraph --></div>
 				<!-- /wp:group --></div>
 				<!-- /wp:column -->
-				
+
 				<!-- wp:column -->
 				<div class="wp-block-column"><!-- wp:group {"style":{"spacing":{"padding":{"top":"30px","right":"30px","bottom":"10px","left":"30px"}}},"backgroundColor":"white"} -->
 				<div class="wp-block-group has-white-background-color has-background" style="padding-top:30px;padding-right:30px;padding-bottom:10px;padding-left:30px"><!-- wp:heading {"textAlign":"center","level":4,"style":{"typography":{"fontSize":72,"lineHeight":"1"},"spacing":{"margin":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}}} -->
 				<h4 class="has-text-align-center" style="font-size:72px;line-height:1;margin-top:0px;margin-right:0px;margin-bottom:0px;margin-left:0px">“</h4>
 				<!-- /wp:heading -->
-				
+
 				<!-- wp:paragraph {"align":"center","style":{"typography":{"fontSize":"18px"}}} -->
 				<p class="has-text-align-center" style="font-size:18px">Quisque ullamcorp nulla elementum, atipo consectetur iaculis vestibulum et faucibus vitae milano pellentesque.</p>
 				<!-- /wp:paragraph -->
-				
+
 				<!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 				<p class="has-text-align-center has-small-font-size"><strong>—Rebecca Jones, Coach</strong></p>
 				<!-- /wp:paragraph --></div>
 				<!-- /wp:group --></div>
 				<!-- /wp:column --></div>
 				<!-- /wp:columns -->
-				
-				<!-- wp:spacer {"height":"70px"} -->
+
+				<!-- wp:spacer {"height":70} -->
 				<div style="height:70px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer --></div>
 				<!-- /wp:group -->',

--- a/frost/inc/patterns/testimonials/testimonials-boxes.php
+++ b/frost/inc/patterns/testimonials/testimonials-boxes.php
@@ -9,61 +9,61 @@ return array(
 	'title'      => __( 'Testimonials with text.', 'frost' ),
 	'categories' => array( 'frost-testimonials' ),
 	'content'    => '<!-- wp:group {"align":"full","textColor":"white","layout":{"inherit":true}} -->
-				<div class="wp-block-group alignfull has-white-color has-text-color"><!-- wp:spacer -->
+				<div class="wp-block-group alignfull has-white-color has-text-color"><!-- wp:spacer {"height":100} -->
 				<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
-				
+
 				<!-- wp:columns {"align":"wide"} -->
 				<div class="wp-block-columns alignwide"><!-- wp:column -->
 				<div class="wp-block-column"><!-- wp:group {"style":{"spacing":{"padding":{"top":"30px","right":"30px","bottom":"10px","left":"30px"}}},"backgroundColor":"black"} -->
 				<div class="wp-block-group has-black-background-color has-background" style="padding-top:30px;padding-right:30px;padding-bottom:10px;padding-left:30px"><!-- wp:heading {"textAlign":"center","level":4,"style":{"typography":{"fontSize":72,"lineHeight":"1"},"spacing":{"margin":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}}} -->
 				<h4 class="has-text-align-center" style="font-size:72px;line-height:1;margin-top:0px;margin-right:0px;margin-bottom:0px;margin-left:0px">“</h4>
 				<!-- /wp:heading -->
-				
+
 				<!-- wp:paragraph {"align":"center","style":{"typography":{"fontSize":"18px"}}} -->
 				<p class="has-text-align-center" style="font-size:18px">Lorem ipsum sit amet, consectetur a adipiscing. Nulla vitae lorem a neque imperdiet sagittis vivamus enim velit.</p>
 				<!-- /wp:paragraph -->
-				
+
 				<!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 				<p class="has-text-align-center has-small-font-size"><strong>—Allison Taylor, Designer</strong></p>
 				<!-- /wp:paragraph --></div>
 				<!-- /wp:group --></div>
 				<!-- /wp:column -->
-				
+
 				<!-- wp:column -->
 				<div class="wp-block-column"><!-- wp:group {"style":{"spacing":{"padding":{"top":"30px","right":"30px","bottom":"10px","left":"30px"}}},"backgroundColor":"black"} -->
 				<div class="wp-block-group has-black-background-color has-background" style="padding-top:30px;padding-right:30px;padding-bottom:10px;padding-left:30px"><!-- wp:heading {"textAlign":"center","level":4,"style":{"typography":{"fontSize":72,"lineHeight":"1"},"spacing":{"margin":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}}} -->
 				<h4 class="has-text-align-center" style="font-size:72px;line-height:1;margin-top:0px;margin-right:0px;margin-bottom:0px;margin-left:0px">“</h4>
 				<!-- /wp:heading -->
-				
+
 				<!-- wp:paragraph {"align":"center","style":{"typography":{"fontSize":"18px"}}} -->
 				<p class="has-text-align-center" style="font-size:18px">Fusce at est sapien. Aliquam tempus nulla nisipt rhoncus, morbi et convallis magna rhoncus morbi viverra ante.</p>
 				<!-- /wp:paragraph -->
-				
+
 				<!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 				<p class="has-text-align-center has-small-font-size"><strong>—Anthony Breck, Developer</strong></p>
 				<!-- /wp:paragraph --></div>
 				<!-- /wp:group --></div>
 				<!-- /wp:column -->
-				
+
 				<!-- wp:column -->
 				<div class="wp-block-column"><!-- wp:group {"style":{"spacing":{"padding":{"top":"30px","right":"30px","bottom":"10px","left":"30px"}}},"backgroundColor":"black"} -->
 				<div class="wp-block-group has-black-background-color has-background" style="padding-top:30px;padding-right:30px;padding-bottom:10px;padding-left:30px"><!-- wp:heading {"textAlign":"center","level":4,"style":{"typography":{"fontSize":72,"lineHeight":"1"},"spacing":{"margin":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}}} -->
 				<h4 class="has-text-align-center" style="font-size:72px;line-height:1;margin-top:0px;margin-right:0px;margin-bottom:0px;margin-left:0px">“</h4>
 				<!-- /wp:heading -->
-				
+
 				<!-- wp:paragraph {"align":"center","style":{"typography":{"fontSize":"18px"}}} -->
 				<p class="has-text-align-center" style="font-size:18px">Quisque ullamcorp nulla elementum, atipo consectetur iaculis vestibulum et faucibus vitae milano pellentesque.</p>
 				<!-- /wp:paragraph -->
-				
+
 				<!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 				<p class="has-text-align-center has-small-font-size"><strong>—Rebecca Jones, Coach</strong></p>
 				<!-- /wp:paragraph --></div>
 				<!-- /wp:group --></div>
 				<!-- /wp:column --></div>
 				<!-- /wp:columns -->
-				
-				<!-- wp:spacer {"height":"70px"} -->
+
+				<!-- wp:spacer {"height":70} -->
 				<div style="height:70px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer --></div>
 				<!-- /wp:group -->',

--- a/frost/inc/patterns/testimonials/testimonials.php
+++ b/frost/inc/patterns/testimonials/testimonials.php
@@ -9,55 +9,55 @@ return array(
 	'title'      => __( 'Testimonials with text.', 'frost' ),
 	'categories' => array( 'frost-testimonials' ),
 	'content'    => '<!-- wp:group {"align":"full","layout":{"inherit":true}} -->
-				<div class="wp-block-group alignfull"><!-- wp:spacer -->
+				<div class="wp-block-group alignfull"><!-- wp:spacer {"height":100} -->
 				<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer -->
-				
+
 				<!-- wp:columns {"align":"wide"} -->
 				<div class="wp-block-columns alignwide"><!-- wp:column -->
 				<div class="wp-block-column"><!-- wp:heading {"level":4,"style":{"typography":{"fontSize":72,"lineHeight":"1"},"spacing":{"margin":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}}} -->
 				<h4 style="font-size:72px;line-height:1;margin-top:0px;margin-right:0px;margin-bottom:0px;margin-left:0px">“</h4>
 				<!-- /wp:heading -->
-				
+
 				<!-- wp:paragraph {"style":{"typography":{"fontSize":"18px"}}} -->
 				<p style="font-size:18px">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla vitae lorem a neque imperdiet sagittis. Vivamus enim velit.</p>
 				<!-- /wp:paragraph -->
-				
+
 				<!-- wp:paragraph {"fontSize":"small"} -->
 				<p class="has-small-font-size"><strong>—Allison Taylor, Designer</strong></p>
 				<!-- /wp:paragraph --></div>
 				<!-- /wp:column -->
-				
+
 				<!-- wp:column -->
 				<div class="wp-block-column"><!-- wp:heading {"level":4,"style":{"typography":{"fontSize":72,"lineHeight":"1"},"spacing":{"margin":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}}} -->
 				<h4 style="font-size:72px;line-height:1;margin-top:0px;margin-right:0px;margin-bottom:0px;margin-left:0px">“</h4>
 				<!-- /wp:heading -->
-				
+
 				<!-- wp:paragraph {"style":{"typography":{"fontSize":"18px"}}} -->
 				<p style="font-size:18px">Fusce at est sapien. Aliquam tempus et nulla nisipt rhoncus, morbi convallis magna swift. Morbi viverra lobortis ante, volutpat ipsum.</p>
 				<!-- /wp:paragraph -->
-				
+
 				<!-- wp:paragraph {"fontSize":"small"} -->
 				<p class="has-small-font-size"><strong>—Anthony Breck, Developer</strong></p>
 				<!-- /wp:paragraph --></div>
 				<!-- /wp:column -->
-				
+
 				<!-- wp:column -->
 				<div class="wp-block-column"><!-- wp:heading {"level":4,"style":{"typography":{"fontSize":72,"lineHeight":"1"},"spacing":{"margin":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}}} -->
 				<h4 style="font-size:72px;line-height:1;margin-top:0px;margin-right:0px;margin-bottom:0px;margin-left:0px">“</h4>
 				<!-- /wp:heading -->
-				
+
 				<!-- wp:paragraph {"style":{"typography":{"fontSize":"18px"}}} -->
 				<p style="font-size:18px">Quisque ullamcorper nulla breu elementum, atipo consectetur ex iaculis quis. Vestibulum et faucibus. Quisque vitae mi pellentesque.</p>
 				<!-- /wp:paragraph -->
-				
+
 				<!-- wp:paragraph {"fontSize":"small"} -->
 				<p class="has-small-font-size"><strong>—Rebecca Jones, Coach</strong></p>
 				<!-- /wp:paragraph --></div>
 				<!-- /wp:column --></div>
 				<!-- /wp:columns -->
-				
-				<!-- wp:spacer {"height":"40px"} -->
+
+				<!-- wp:spacer {"height":40} -->
 				<div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
 				<!-- /wp:spacer --></div>
 				<!-- /wp:group -->',


### PR DESCRIPTION
WordPress 5.9 does not support custom units (px, %, em, etc.) on the Spacer block. This functionality is only supported in the Gutenberg plugin. This PR removes the units to ensure compatibility with 5.9 when Gutenberg is not active.