### PR TITLE
Create .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,9 @@
+* text=auto
+
+.gitattributes export-ignore
+.gitignore export-ignore
+/.github export-ignore
+.stylelintrc.json export-ignore
+phpcs.xml export-ignore
+composer.lock export-ignore
+/.wordpress-org export-ignore


### PR DESCRIPTION
Ignores several files when a user downloads the repository/release

Fixes https://github.com/wpengine/frost/issues/43