### PR TITLE
Fix skipped h3 in team patterns

### DIFF
--- a/inc/patterns/general/general-team-four-columns-black-background.php
+++ b/inc/patterns/general/general-team-four-columns-black-background.php
@@ -32,8 +32,8 @@ return array(
 				<figure class="wp-block-image size-full"><img src="' . esc_url( __( 'https://frostwp.com/wp-content/uploads/2021/12/sample-white_800x800.jpg', 'frost' ) ) . '"  alt="' . esc_attr__( 'Sample Image', 'frost' ) . '" class="wp-image-3488"/></figure>
 				<!-- /wp:image -->
 
-				<!-- wp:heading {"textAlign":"center","level":4,"fontSize":"medium"} -->
-				<h4 class="has-text-align-center has-medium-font-size" id="member-name-1">' . esc_html__( 'Member Name', 'frost' ) . '</h4>
+				<!-- wp:heading {"textAlign":"center","level":3,"fontSize":"medium"} -->
+				<h3 class="has-text-align-center has-medium-font-size" id="member-name-1">' . esc_html__( 'Member Name', 'frost' ) . '</h3>
 				<!-- /wp:heading -->
 
 				<!-- wp:paragraph {"align":"center","style":{"elements":{"link":{"color":[]}},"typography":{"fontSize":"18px"}}} -->
@@ -50,8 +50,8 @@ return array(
 				<figure class="wp-block-image size-full"><img src="' . esc_url( __( 'https://frostwp.com/wp-content/uploads/2021/12/sample-white_800x800.jpg', 'frost' ) ) . '"  alt="' . esc_attr__( 'Sample Image', 'frost' ) . '" class="wp-image-3488"/></figure>
 				<!-- /wp:image -->
 
-				<!-- wp:heading {"textAlign":"center","level":4,"fontSize":"medium"} -->
-				<h4 class="has-text-align-center has-medium-font-size" id="member-name-2">' . esc_html__( 'Member Name', 'frost' ) . '</h4>
+				<!-- wp:heading {"textAlign":"center","level":3,"fontSize":"medium"} -->
+				<h3 class="has-text-align-center has-medium-font-size" id="member-name-2">' . esc_html__( 'Member Name', 'frost' ) . '</h3>
 				<!-- /wp:heading -->
 
 				<!-- wp:paragraph {"align":"center","style":{"typography":{"fontSize":"18px"}}} -->
@@ -68,8 +68,8 @@ return array(
 				<figure class="wp-block-image size-full"><img src="' . esc_url( __( 'https://frostwp.com/wp-content/uploads/2021/12/sample-white_800x800.jpg', 'frost' ) ) . '"  alt="' . esc_attr__( 'Sample Image', 'frost' ) . '" class="wp-image-3488"/></figure>
 				<!-- /wp:image -->
 
-				<!-- wp:heading {"textAlign":"center","level":4,"fontSize":"medium"} -->
-				<h4 class="has-text-align-center has-medium-font-size" id="member-name-3">' . esc_html__( 'Member Name', 'frost' ) . '</h4>
+				<!-- wp:heading {"textAlign":"center","level":3,"fontSize":"medium"} -->
+				<h3 class="has-text-align-center has-medium-font-size" id="member-name-3">' . esc_html__( 'Member Name', 'frost' ) . '</h3>
 				<!-- /wp:heading -->
 
 				<!-- wp:paragraph {"align":"center","style":{"typography":{"fontSize":"18px"}}} -->
@@ -86,8 +86,8 @@ return array(
 				<figure class="wp-block-image size-full"><img src="' . esc_url( __( 'https://frostwp.com/wp-content/uploads/2021/12/sample-white_800x800.jpg', 'frost' ) ) . '"  alt="' . esc_attr__( 'Sample Image', 'frost' ) . '" class="wp-image-3488"/></figure>
 				<!-- /wp:image -->
 
-				<!-- wp:heading {"textAlign":"center","level":4,"fontSize":"medium"} -->
-				<h4 class="has-text-align-center has-medium-font-size" id="member-name-4">' . esc_html__( 'Member Name', 'frost' ) . '</h4>
+				<!-- wp:heading {"textAlign":"center","level":3,"fontSize":"medium"} -->
+				<h3 class="has-text-align-center has-medium-font-size" id="member-name-4">' . esc_html__( 'Member Name', 'frost' ) . '</h3>
 				<!-- /wp:heading -->
 
 				<!-- wp:paragraph {"align":"center","style":{"typography":{"fontSize":"18px"}}} -->

--- a/inc/patterns/general/general-team-four-columns.php
+++ b/inc/patterns/general/general-team-four-columns.php
@@ -32,8 +32,8 @@ return array(
 				<figure class="wp-block-image size-full"><img src="' . esc_url( __( 'https://frostwp.com/wp-content/uploads/2021/12/sample-black_800x800.jpg', 'frost' ) ) . '"  alt="' . esc_attr__( 'Sample Image', 'frost' ) . '" class="wp-image-3489"/></figure>
 				<!-- /wp:image -->
 
-				<!-- wp:heading {"textAlign":"center","level":4,"fontSize":"medium"} -->
-				<h4 class="has-text-align-center has-medium-font-size" id="member-name-1">' . esc_html__( 'Member Name', 'frost' ) . '</h4>
+				<!-- wp:heading {"textAlign":"center","level":3,"fontSize":"medium"} -->
+				<h3 class="has-text-align-center has-medium-font-size" id="member-name-1">' . esc_html__( 'Member Name', 'frost' ) . '</h3>
 				<!-- /wp:heading -->
 
 				<!-- wp:paragraph {"align":"center","style":{"typography":{"fontSize":"18px"}}} -->
@@ -50,8 +50,8 @@ return array(
 				<figure class="wp-block-image size-full"><img src="' . esc_url( __( 'https://frostwp.com/wp-content/uploads/2021/12/sample-black_800x800.jpg', 'frost' ) ) . '"  alt="' . esc_attr__( 'Sample Image', 'frost' ) . '" class="wp-image-3489"/></figure>
 				<!-- /wp:image -->
 
-				<!-- wp:heading {"textAlign":"center","level":4,"fontSize":"medium"} -->
-				<h4 class="has-text-align-center has-medium-font-size" id="member-name-2">' . esc_html__( 'Member Name', 'frost' ) . '</h4>
+				<!-- wp:heading {"textAlign":"center","level":3,"fontSize":"medium"} -->
+				<h3 class="has-text-align-center has-medium-font-size" id="member-name-2">' . esc_html__( 'Member Name', 'frost' ) . '</h3>
 				<!-- /wp:heading -->
 
 				<!-- wp:paragraph {"align":"center","style":{"typography":{"fontSize":"18px"}}} -->
@@ -68,8 +68,8 @@ return array(
 				<figure class="wp-block-image size-full"><img src="' . esc_url( __( 'https://frostwp.com/wp-content/uploads/2021/12/sample-black_800x800.jpg', 'frost' ) ) . '"  alt="' . esc_attr__( 'Sample Image', 'frost' ) . '" class="wp-image-3489"/></figure>
 				<!-- /wp:image -->
 
-				<!-- wp:heading {"textAlign":"center","level":4,"fontSize":"medium"} -->
-				<h4 class="has-text-align-center has-medium-font-size" id="member-name-3">' . esc_html__( 'Member Name', 'frost' ) . '</h4>
+				<!-- wp:heading {"textAlign":"center","level":3,"fontSize":"medium"} -->
+				<h3 class="has-text-align-center has-medium-font-size" id="member-name-3">' . esc_html__( 'Member Name', 'frost' ) . '</h3>
 				<!-- /wp:heading -->
 
 				<!-- wp:paragraph {"align":"center","style":{"typography":{"fontSize":"18px"}}} -->
@@ -86,8 +86,8 @@ return array(
 				<figure class="wp-block-image size-full"><img src="' . esc_url( __( 'https://frostwp.com/wp-content/uploads/2021/12/sample-black_800x800.jpg', 'frost' ) ) . '"  alt="' . esc_attr__( 'Sample Image', 'frost' ) . '" class="wp-image-3489"/></figure>
 				<!-- /wp:image -->
 
-				<!-- wp:heading {"textAlign":"center","level":4,"fontSize":"medium"} -->
-				<h4 class="has-text-align-center has-medium-font-size" id="member-name-4">' . esc_html__( 'Member Name', 'frost' ) . '</h4>
+				<!-- wp:heading {"textAlign":"center","level":3,"fontSize":"medium"} -->
+				<h3 class="has-text-align-center has-medium-font-size" id="member-name-4">' . esc_html__( 'Member Name', 'frost' ) . '</h3>
 				<!-- /wp:heading -->
 
 				<!-- wp:paragraph {"align":"center","style":{"typography":{"fontSize":"18px"}}} -->

--- a/inc/patterns/general/general-team-two-columns-black-background.php
+++ b/inc/patterns/general/general-team-two-columns-black-background.php
@@ -38,8 +38,8 @@ return array(
 				<!-- /wp:column -->
 
 				<!-- wp:column {"width":"75%"} -->
-				<div class="wp-block-column" style="flex-basis:75%"><!-- wp:heading {"level":4,"fontSize":"medium"} -->
-				<h4 class="has-medium-font-size" id="member-name">' . esc_html__( 'Member Name', 'frost' ) . '</h4>
+				<div class="wp-block-column" style="flex-basis:75%"><!-- wp:heading {"level":3,"fontSize":"medium"} -->
+				<h3 class="has-medium-font-size" id="member-name">' . esc_html__( 'Member Name', 'frost' ) . '</h3>
 				<!-- /wp:heading -->
 
 				<!-- wp:paragraph {"style":{"typography":{"fontSize":"18px"}}} -->
@@ -56,8 +56,8 @@ return array(
 				<!-- /wp:column -->
 
 				<!-- wp:column {"width":"75%"} -->
-				<div class="wp-block-column" style="flex-basis:75%"><!-- wp:heading {"level":4,"fontSize":"medium"} -->
-				<h4 class="has-medium-font-size" id="member-name">' . esc_html__( 'Member Name', 'frost' ) . '</h4>
+				<div class="wp-block-column" style="flex-basis:75%"><!-- wp:heading {"level":3,"fontSize":"medium"} -->
+				<h3 class="has-medium-font-size" id="member-name">' . esc_html__( 'Member Name', 'frost' ) . '</h3>
 				<!-- /wp:heading -->
 
 				<!-- wp:paragraph {"style":{"typography":{"fontSize":"18px"}}} -->
@@ -74,8 +74,8 @@ return array(
 				<!-- /wp:column -->
 
 				<!-- wp:column {"width":"75%"} -->
-				<div class="wp-block-column" style="flex-basis:75%"><!-- wp:heading {"level":4,"fontSize":"medium"} -->
-				<h4 class="has-medium-font-size" id="member-name-1">' . esc_html__( 'Member Name', 'frost' ) . '</h4>
+				<div class="wp-block-column" style="flex-basis:75%"><!-- wp:heading {"level":3,"fontSize":"medium"} -->
+				<h3 class="has-medium-font-size" id="member-name-1">' . esc_html__( 'Member Name', 'frost' ) . '</h3>
 				<!-- /wp:heading -->
 
 				<!-- wp:paragraph {"style":{"typography":{"fontSize":"18px"}}} -->
@@ -94,8 +94,8 @@ return array(
 				<!-- /wp:column -->
 
 				<!-- wp:column {"width":"75%"} -->
-				<div class="wp-block-column" style="flex-basis:75%"><!-- wp:heading {"level":4,"fontSize":"medium"} -->
-				<h4 class="has-medium-font-size" id="member-name-2">' . esc_html__( 'Member Name', 'frost' ) . '</h4>
+				<div class="wp-block-column" style="flex-basis:75%"><!-- wp:heading {"level":3,"fontSize":"medium"} -->
+				<h3 class="has-medium-font-size" id="member-name-2">' . esc_html__( 'Member Name', 'frost' ) . '</h3>
 				<!-- /wp:heading -->
 
 				<!-- wp:paragraph {"style":{"typography":{"fontSize":"18px"}}} -->
@@ -112,8 +112,8 @@ return array(
 				<!-- /wp:column -->
 
 				<!-- wp:column {"width":"75%"} -->
-				<div class="wp-block-column" style="flex-basis:75%"><!-- wp:heading {"level":4,"fontSize":"medium"} -->
-				<h4 class="has-medium-font-size" id="member-name">' . esc_html__( 'Member Name', 'frost' ) . '</h4>
+				<div class="wp-block-column" style="flex-basis:75%"><!-- wp:heading {"level":3,"fontSize":"medium"} -->
+				<h3 class="has-medium-font-size" id="member-name">' . esc_html__( 'Member Name', 'frost' ) . '</h3>
 				<!-- /wp:heading -->
 
 				<!-- wp:paragraph {"style":{"typography":{"fontSize":"18px"}}} -->
@@ -130,8 +130,8 @@ return array(
 				<!-- /wp:column -->
 
 				<!-- wp:column {"width":"75%"} -->
-				<div class="wp-block-column" style="flex-basis:75%"><!-- wp:heading {"level":4,"fontSize":"medium"} -->
-				<h4 class="has-medium-font-size" id="member-name">' . esc_html__( 'Member Name', 'frost' ) . '</h4>
+				<div class="wp-block-column" style="flex-basis:75%"><!-- wp:heading {"level":3,"fontSize":"medium"} -->
+				<h3 class="has-medium-font-size" id="member-name">' . esc_html__( 'Member Name', 'frost' ) . '</h3>
 				<!-- /wp:heading -->
 
 				<!-- wp:paragraph {"style":{"typography":{"fontSize":"18px"}}} -->

--- a/inc/patterns/general/general-team-two-columns.php
+++ b/inc/patterns/general/general-team-two-columns.php
@@ -38,8 +38,8 @@ return array(
 				<!-- /wp:column -->
 
 				<!-- wp:column {"width":"75%"} -->
-				<div class="wp-block-column" style="flex-basis:75%"><!-- wp:heading {"level":4,"fontSize":"medium"} -->
-				<h4 class="has-medium-font-size" id="member-name-1">' . esc_html__( 'Member Name', 'frost' ) . '</h4>
+				<div class="wp-block-column" style="flex-basis:75%"><!-- wp:heading {"level":3,"fontSize":"medium"} -->
+				<h3 class="has-medium-font-size" id="member-name-1">' . esc_html__( 'Member Name', 'frost' ) . '</h3>
 				<!-- /wp:heading -->
 
 				<!-- wp:paragraph {"style":{"typography":{"fontSize":"18px"}}} -->
@@ -56,8 +56,8 @@ return array(
 				<!-- /wp:column -->
 
 				<!-- wp:column {"width":"75%"} -->
-				<div class="wp-block-column" style="flex-basis:75%"><!-- wp:heading {"level":4,"fontSize":"medium"} -->
-				<h4 class="has-medium-font-size" id="member-name-2">' . esc_html__( 'Member Name', 'frost' ) . '</h4>
+				<div class="wp-block-column" style="flex-basis:75%"><!-- wp:heading {"level":3,"fontSize":"medium"} -->
+				<h3 class="has-medium-font-size" id="member-name-2">' . esc_html__( 'Member Name', 'frost' ) . '</h3>
 				<!-- /wp:heading -->
 
 				<!-- wp:paragraph {"style":{"typography":{"fontSize":"18px"}}} -->
@@ -74,8 +74,8 @@ return array(
 				<!-- /wp:column -->
 
 				<!-- wp:column {"width":"75%"} -->
-				<div class="wp-block-column" style="flex-basis:75%"><!-- wp:heading {"level":4,"fontSize":"medium"} -->
-				<h4 class="has-medium-font-size" id="member-name">' . esc_html__( 'Member Name', 'frost' ) . '</h4>
+				<div class="wp-block-column" style="flex-basis:75%"><!-- wp:heading {"level":3,"fontSize":"medium"} -->
+				<h3 class="has-medium-font-size" id="member-name">' . esc_html__( 'Member Name', 'frost' ) . '</h3>
 				<!-- /wp:heading -->
 
 				<!-- wp:paragraph {"style":{"typography":{"fontSize":"18px"}}} -->
@@ -94,8 +94,8 @@ return array(
 				<!-- /wp:column -->
 
 				<!-- wp:column {"width":"75%"} -->
-				<div class="wp-block-column" style="flex-basis:75%"><!-- wp:heading {"level":4,"fontSize":"medium"} -->
-				<h4 class="has-medium-font-size" id="member-name">' . esc_html__( 'Member Name', 'frost' ) . '</h4>
+				<div class="wp-block-column" style="flex-basis:75%"><!-- wp:heading {"level":3,"fontSize":"medium"} -->
+				<h3 class="has-medium-font-size" id="member-name">' . esc_html__( 'Member Name', 'frost' ) . '</h3>
 				<!-- /wp:heading -->
 
 				<!-- wp:paragraph {"style":{"typography":{"fontSize":"18px"}}} -->
@@ -112,8 +112,8 @@ return array(
 				<!-- /wp:column -->
 
 				<!-- wp:column {"width":"75%"} -->
-				<div class="wp-block-column" style="flex-basis:75%"><!-- wp:heading {"level":4,"fontSize":"medium"} -->
-				<h4 class="has-medium-font-size" id="member-name">' . esc_html__( 'Member Name', 'frost' ) . '</h4>
+				<div class="wp-block-column" style="flex-basis:75%"><!-- wp:heading {"level":3,"fontSize":"medium"} -->
+				<h3 class="has-medium-font-size" id="member-name">' . esc_html__( 'Member Name', 'frost' ) . '</h3>
 				<!-- /wp:heading -->
 
 				<!-- wp:paragraph {"style":{"typography":{"fontSize":"18px"}}} -->
@@ -130,8 +130,8 @@ return array(
 				<!-- /wp:column -->
 
 				<!-- wp:column {"width":"75%"} -->
-				<div class="wp-block-column" style="flex-basis:75%"><!-- wp:heading {"level":4,"fontSize":"medium"} -->
-				<h4 class="has-medium-font-size" id="member-name">' . esc_html__( 'Member Name', 'frost' ) . '</h4>
+				<div class="wp-block-column" style="flex-basis:75%"><!-- wp:heading {"level":3,"fontSize":"medium"} -->
+				<h3 class="has-medium-font-size" id="member-name">' . esc_html__( 'Member Name', 'frost' ) . '</h3>
 				<!-- /wp:heading -->
 
 				<!-- wp:paragraph {"style":{"typography":{"fontSize":"18px"}}} -->


### PR DESCRIPTION
Fixes #52 

Each team pattern has a `h2` for the section heading and then skips to `h4` for the team members name.

This PR addresses the skipped heading and changes all of the `h4`s to `h3`s

Since `.has-medium-font-size` is already in place, the appearance is not effected by this change.