### PR TITLE
Replace `main` & `base` with `foreground` & `background`

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -60,8 +60,8 @@ function frost_register_block_styles() {
 
 	$block_styles = array(
 		'core/button'          => array(
-			'fill-base'    => __( 'Fill Base', 'frost' ),
-			'outline-base' => __( 'Outline Base', 'frost' ),
+			'fill-background'    => __( 'Fill Background', 'frost' ),
+			'outline-background' => __( 'Outline Background', 'frost' ),
 		),
 		'core/group'           => array(
 			'shadow'       => __( 'Shadow', 'frost' ),
@@ -79,9 +79,9 @@ function frost_register_block_styles() {
 		),
 		'core/navigation-link' => array(
 			'fill'         => __( 'Fill', 'frost' ),
-			'fill-base'    => __( 'Fill Base', 'frost' ),
+			'fill-background'    => __( 'Fill Background', 'frost' ),
 			'outline'      => __( 'Outline', 'frost' ),
-			'outline-base' => __( 'Outline Base', 'frost' ),
+			'outline-background' => __( 'Outline Background', 'frost' ),
 		),
 	);
 

--- a/patterns/footer-default-main-background.php
+++ b/patterns/footer-default-main-background.php
@@ -8,8 +8,8 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"40px","bottom":"40px"},"margin":{"top":"0px"}},"elements":{"link":{"color":{"text":"var:preset|color|background"}}}},"backgroundColor":"main","textColor":"background","layout":{"inherit":true},"fontSize":"small"} -->
-<div class="wp-block-group alignfull has-background-color has-main-background-color has-text-color has-background has-link-color has-small-font-size" style="margin-top:0px;padding-top:40px;padding-bottom:40px">
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"40px","bottom":"40px"},"margin":{"top":"0px"}},"elements":{"link":{"color":{"text":"var:preset|color|background"}}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true},"fontSize":"small"} -->
+<div class="wp-block-group alignfull has-background-color has-foreground-background-color has-text-color has-background has-link-color has-small-font-size" style="margin-top:0px;padding-top:40px;padding-bottom:40px">
 <!-- wp:group {"align":"wide","layout":{"type":"flex","allowOrientation":false,"justifyContent":"space-between"}} -->
 <div class="wp-block-group alignwide">
 <!-- wp:paragraph -->

--- a/patterns/footer-default-main-background.php
+++ b/patterns/footer-default-main-background.php
@@ -8,8 +8,8 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"40px","bottom":"40px"},"margin":{"top":"0px"}},"elements":{"link":{"color":{"text":"var:preset|color|base"}}}},"backgroundColor":"main","textColor":"base","layout":{"inherit":true},"fontSize":"small"} -->
-<div class="wp-block-group alignfull has-base-color has-main-background-color has-text-color has-background has-link-color has-small-font-size" style="margin-top:0px;padding-top:40px;padding-bottom:40px">
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"40px","bottom":"40px"},"margin":{"top":"0px"}},"elements":{"link":{"color":{"text":"var:preset|color|background"}}}},"backgroundColor":"main","textColor":"background","layout":{"inherit":true},"fontSize":"small"} -->
+<div class="wp-block-group alignfull has-background-color has-main-background-color has-text-color has-background has-link-color has-small-font-size" style="margin-top:0px;padding-top:40px;padding-bottom:40px">
 <!-- wp:group {"align":"wide","layout":{"type":"flex","allowOrientation":false,"justifyContent":"space-between"}} -->
 <div class="wp-block-group alignwide">
 <!-- wp:paragraph -->

--- a/patterns/footer-mega-main-background.php
+++ b/patterns/footer-mega-main-background.php
@@ -8,8 +8,8 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|base"}}},"typography":{"fontSize":"18px"},"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"main","textColor":"base","layout":{"inherit":true}} -->
-<div class="wp-block-group alignfull has-base-color has-main-background-color has-text-color has-background has-link-color" style="font-size:18px;margin-top:0px">
+<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"typography":{"fontSize":"18px"},"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"main","textColor":"background","layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull has-background-color has-main-background-color has-text-color has-background has-link-color" style="font-size:18px;margin-top:0px">
 <!-- wp:columns {"align":"wide","style":{"elements":{"link":{"color":[]}},"spacing":{"padding":{"top":"100px","bottom":"100px"},"blockGap":"100px"}}} -->
 <div class="wp-block-columns alignwide has-link-color" style="padding-top:100px;padding-bottom:100px">
 <!-- wp:column {"width":"50%"} -->
@@ -22,8 +22,8 @@
 <!-- /wp:paragraph -->
 <!-- wp:buttons -->
 <div class="wp-block-buttons">
-<!-- wp:button {"style":{"border":{"radius":0}},"className":"is-style-fill-base"} -->
-<div class="wp-block-button is-style-fill-base">
+<!-- wp:button {"style":{"border":{"radius":0}},"className":"is-style-fill-background"} -->
+<div class="wp-block-button is-style-fill-background">
 <a class="wp-block-button__link no-border-radius" href="#"><?php echo esc_html__( 'Learn More', 'frost' ); ?></a>
 </div>
 <!-- /wp:button -->

--- a/patterns/footer-mega-main-background.php
+++ b/patterns/footer-mega-main-background.php
@@ -8,8 +8,8 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"typography":{"fontSize":"18px"},"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"main","textColor":"background","layout":{"inherit":true}} -->
-<div class="wp-block-group alignfull has-background-color has-main-background-color has-text-color has-background has-link-color" style="font-size:18px;margin-top:0px">
+<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"typography":{"fontSize":"18px"},"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull has-background-color has-foreground-background-color has-text-color has-background has-link-color" style="font-size:18px;margin-top:0px">
 <!-- wp:columns {"align":"wide","style":{"elements":{"link":{"color":[]}},"spacing":{"padding":{"top":"100px","bottom":"100px"},"blockGap":"100px"}}} -->
 <div class="wp-block-columns alignwide has-link-color" style="padding-top:100px;padding-bottom:100px">
 <!-- wp:column {"width":"50%"} -->

--- a/patterns/footer-split-main-background.php
+++ b/patterns/footer-split-main-background.php
@@ -8,8 +8,8 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"padding":{"top":"40vh","bottom":"40px"},"margin":{"top":"0px"}}},"backgroundColor":"main","textColor":"background","layout":{"inherit":true},"fontSize":"small"} -->
-<div class="wp-block-group alignfull has-background-color has-main-background-color has-text-color has-background has-link-color has-small-font-size" style="margin-top:0px;padding-top:40vh;padding-bottom:40px">
+<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"padding":{"top":"40vh","bottom":"40px"},"margin":{"top":"0px"}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true},"fontSize":"small"} -->
+<div class="wp-block-group alignfull has-background-color has-foreground-background-color has-text-color has-background has-link-color has-small-font-size" style="margin-top:0px;padding-top:40vh;padding-bottom:40px">
 <!-- wp:columns {"verticalAlignment":"center","align":"wide"} -->
 <div class="wp-block-columns alignwide are-vertically-aligned-center">
 <!-- wp:column {"verticalAlignment":"center","width":"75%"} -->

--- a/patterns/footer-split-main-background.php
+++ b/patterns/footer-split-main-background.php
@@ -8,8 +8,8 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|base"}}},"spacing":{"padding":{"top":"40vh","bottom":"40px"},"margin":{"top":"0px"}}},"backgroundColor":"main","textColor":"base","layout":{"inherit":true},"fontSize":"small"} -->
-<div class="wp-block-group alignfull has-base-color has-main-background-color has-text-color has-background has-link-color has-small-font-size" style="margin-top:0px;padding-top:40vh;padding-bottom:40px">
+<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"padding":{"top":"40vh","bottom":"40px"},"margin":{"top":"0px"}}},"backgroundColor":"main","textColor":"background","layout":{"inherit":true},"fontSize":"small"} -->
+<div class="wp-block-group alignfull has-background-color has-main-background-color has-text-color has-background has-link-color has-small-font-size" style="margin-top:0px;padding-top:40vh;padding-bottom:40px">
 <!-- wp:columns {"verticalAlignment":"center","align":"wide"} -->
 <div class="wp-block-columns alignwide are-vertically-aligned-center">
 <!-- wp:column {"verticalAlignment":"center","width":"75%"} -->

--- a/patterns/footer-stacked-main-background.php
+++ b/patterns/footer-stacked-main-background.php
@@ -7,8 +7,8 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|base"}}},"spacing":{"padding":{"top":"100px","bottom":"40px"},"margin":{"top":"0px"}}},"backgroundColor":"main","textColor":"base","layout":{"inherit":true}} -->
-<div class="wp-block-group alignfull has-base-color has-main-background-color has-text-color has-background has-link-color" style="margin-top:0px;padding-top:100px;padding-bottom:40px">
+<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"padding":{"top":"100px","bottom":"40px"},"margin":{"top":"0px"}}},"backgroundColor":"main","textColor":"background","layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull has-background-color has-main-background-color has-text-color has-background has-link-color" style="margin-top:0px;padding-top:100px;padding-bottom:40px">
 <!-- wp:heading {"textAlign":"center","style":{"typography":{"fontStyle":"normal","fontWeight":"400"},"spacing":{"margin":{"bottom":"20px"}}},"fontSize":"max-48"} -->
 <h2 class="has-text-align-center has-max-48-font-size" id="let-s-connect" style="font-style:normal;font-weight:400;margin-bottom:20px"><?php echo esc_html__( 'Let’s Connect', 'frost' ); ?></h2>
 <!-- /wp:heading -->
@@ -17,8 +17,8 @@
 <!-- /wp:paragraph -->
 <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center","orientation":"horizontal"}} -->
 <div class="wp-block-buttons">
-<!-- wp:button {"style":{"border":{"radius":0}},"className":"is-style-outline-base"} -->
-<div class="wp-block-button is-style-outline-base"><a class="wp-block-button__link no-border-radius" href="#"><?php echo esc_html__( 'Get in Touch', 'frost' ); ?> →</a></div>
+<!-- wp:button {"style":{"border":{"radius":0}},"className":"is-style-outline-background"} -->
+<div class="wp-block-button is-style-outline-background"><a class="wp-block-button__link no-border-radius" href="#"><?php echo esc_html__( 'Get in Touch', 'frost' ); ?> →</a></div>
 <!-- /wp:button -->
 </div>
 <!-- /wp:buttons -->

--- a/patterns/footer-stacked-main-background.php
+++ b/patterns/footer-stacked-main-background.php
@@ -7,8 +7,8 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"padding":{"top":"100px","bottom":"40px"},"margin":{"top":"0px"}}},"backgroundColor":"main","textColor":"background","layout":{"inherit":true}} -->
-<div class="wp-block-group alignfull has-background-color has-main-background-color has-text-color has-background has-link-color" style="margin-top:0px;padding-top:100px;padding-bottom:40px">
+<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"padding":{"top":"100px","bottom":"40px"},"margin":{"top":"0px"}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull has-background-color has-foreground-background-color has-text-color has-background has-link-color" style="margin-top:0px;padding-top:100px;padding-bottom:40px">
 <!-- wp:heading {"textAlign":"center","style":{"typography":{"fontStyle":"normal","fontWeight":"400"},"spacing":{"margin":{"bottom":"20px"}}},"fontSize":"max-48"} -->
 <h2 class="has-text-align-center has-max-48-font-size" id="let-s-connect" style="font-style:normal;font-weight:400;margin-bottom:20px"><?php echo esc_html__( 'Let’s Connect', 'frost' ); ?></h2>
 <!-- /wp:heading -->

--- a/patterns/footer-three-columns-main-background.php
+++ b/patterns/footer-three-columns-main-background.php
@@ -8,8 +8,8 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"padding":{"top":"40px","bottom":"40px"},"margin":{"top":"0px"}}},"backgroundColor":"main","textColor":"background","layout":{"inherit":true},"fontSize":"small"} -->
-<div class="wp-block-group alignfull has-background-color has-main-background-color has-text-color has-background has-link-color has-small-font-size" style="margin-top:0px;padding-top:40px;padding-bottom:40px">
+<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"padding":{"top":"40px","bottom":"40px"},"margin":{"top":"0px"}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true},"fontSize":"small"} -->
+<div class="wp-block-group alignfull has-background-color has-foreground-background-color has-text-color has-background has-link-color has-small-font-size" style="margin-top:0px;padding-top:40px;padding-bottom:40px">
 <!-- wp:group {"align":"wide","layout":{"type":"flex","allowOrientation":false,"justifyContent":"space-between"}} -->
 <div class="wp-block-group alignwide">
 <!-- wp:paragraph -->
@@ -18,7 +18,7 @@
 <!-- wp:paragraph -->
 <p><a href="#"><?php echo esc_html__( 'Privacy Policy', 'frost' ); ?></a> · <a href="#"><?php echo esc_html__( 'Terms of Service', 'frost' ); ?></a> · <a href="#"><?php echo esc_html__( 'Contact Us', 'frost' ); ?></a></p>
 <!-- /wp:paragraph -->
-<!-- wp:social-links {"iconColor":"main","iconColorValue":"#000","iconBackgroundColor":"background","iconBackgroundColorValue":"#fff","className":"is-style-default","style":{"spacing":{"blockGap":"10px"}}} -->
+<!-- wp:social-links {"iconColor":"foreground","iconColorValue":"#000","iconBackgroundColor":"background","iconBackgroundColorValue":"#fff","className":"is-style-default","style":{"spacing":{"blockGap":"10px"}}} -->
 <ul class="wp-block-social-links has-icon-color has-icon-background-color is-style-default">
 <!-- wp:social-link {"url":"#","service":"facebook"} /-->
 <!-- wp:social-link {"url":"#","service":"instagram"} /-->

--- a/patterns/footer-three-columns-main-background.php
+++ b/patterns/footer-three-columns-main-background.php
@@ -8,8 +8,8 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|base"}}},"spacing":{"padding":{"top":"40px","bottom":"40px"},"margin":{"top":"0px"}}},"backgroundColor":"main","textColor":"base","layout":{"inherit":true},"fontSize":"small"} -->
-<div class="wp-block-group alignfull has-base-color has-main-background-color has-text-color has-background has-link-color has-small-font-size" style="margin-top:0px;padding-top:40px;padding-bottom:40px">
+<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"padding":{"top":"40px","bottom":"40px"},"margin":{"top":"0px"}}},"backgroundColor":"main","textColor":"background","layout":{"inherit":true},"fontSize":"small"} -->
+<div class="wp-block-group alignfull has-background-color has-main-background-color has-text-color has-background has-link-color has-small-font-size" style="margin-top:0px;padding-top:40px;padding-bottom:40px">
 <!-- wp:group {"align":"wide","layout":{"type":"flex","allowOrientation":false,"justifyContent":"space-between"}} -->
 <div class="wp-block-group alignwide">
 <!-- wp:paragraph -->
@@ -18,7 +18,7 @@
 <!-- wp:paragraph -->
 <p><a href="#"><?php echo esc_html__( 'Privacy Policy', 'frost' ); ?></a> · <a href="#"><?php echo esc_html__( 'Terms of Service', 'frost' ); ?></a> · <a href="#"><?php echo esc_html__( 'Contact Us', 'frost' ); ?></a></p>
 <!-- /wp:paragraph -->
-<!-- wp:social-links {"iconColor":"main","iconColorValue":"#000","iconBackgroundColor":"base","iconBackgroundColorValue":"#fff","className":"is-style-default","style":{"spacing":{"blockGap":"10px"}}} -->
+<!-- wp:social-links {"iconColor":"main","iconColorValue":"#000","iconBackgroundColor":"background","iconBackgroundColorValue":"#fff","className":"is-style-default","style":{"spacing":{"blockGap":"10px"}}} -->
 <ul class="wp-block-social-links has-icon-color has-icon-background-color is-style-default">
 <!-- wp:social-link {"url":"#","service":"facebook"} /-->
 <!-- wp:social-link {"url":"#","service":"instagram"} /-->

--- a/patterns/footer-three-columns.php
+++ b/patterns/footer-three-columns.php
@@ -18,7 +18,7 @@
 <!-- wp:paragraph -->
 <p><a href="#"><?php echo esc_html__( 'Privacy Policy', 'frost' ); ?></a> · <a href="#"><?php echo esc_html__( 'Terms of Service', 'frost' ); ?></a> · <a href="#"><?php echo esc_html__( 'Contact Us', 'frost' ); ?></a></p>
 <!-- /wp:paragraph -->
-<!-- wp:social-links {"iconColor":"base","iconColorValue":"#fff","iconBackgroundColor":"main","iconBackgroundColorValue":"#000","className":"is-style-default","style":{"spacing":{"blockGap":"10px"}}} -->
+<!-- wp:social-links {"iconColor":"background","iconColorValue":"#fff","iconBackgroundColor":"main","iconBackgroundColorValue":"#000","className":"is-style-default","style":{"spacing":{"blockGap":"10px"}}} -->
 <ul class="wp-block-social-links has-icon-color has-icon-background-color is-style-default">
 <!-- wp:social-link {"url":"#","service":"facebook"} /-->
 <!-- wp:social-link {"url":"#","service":"instagram"} /-->

--- a/patterns/footer-three-columns.php
+++ b/patterns/footer-three-columns.php
@@ -18,7 +18,7 @@
 <!-- wp:paragraph -->
 <p><a href="#"><?php echo esc_html__( 'Privacy Policy', 'frost' ); ?></a> · <a href="#"><?php echo esc_html__( 'Terms of Service', 'frost' ); ?></a> · <a href="#"><?php echo esc_html__( 'Contact Us', 'frost' ); ?></a></p>
 <!-- /wp:paragraph -->
-<!-- wp:social-links {"iconColor":"background","iconColorValue":"#fff","iconBackgroundColor":"main","iconBackgroundColorValue":"#000","className":"is-style-default","style":{"spacing":{"blockGap":"10px"}}} -->
+<!-- wp:social-links {"iconColor":"background","iconColorValue":"#fff","iconBackgroundColor":"foreground","iconBackgroundColorValue":"#000","className":"is-style-default","style":{"spacing":{"blockGap":"10px"}}} -->
 <ul class="wp-block-social-links has-icon-color has-icon-background-color is-style-default">
 <!-- wp:social-link {"url":"#","service":"facebook"} /-->
 <!-- wp:social-link {"url":"#","service":"instagram"} /-->

--- a/patterns/general-boxes-three-main-background.php
+++ b/patterns/general-boxes-three-main-background.php
@@ -7,8 +7,8 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"main","layout":{"inherit":true}} -->
-<div class="wp-block-group alignfull has-main-background-color has-background" style="margin-top:0px">
+<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"foreground","layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull has-foreground-background-color has-background" style="margin-top:0px">
 <!-- wp:spacer {"height":100} -->
 <div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->

--- a/patterns/general-boxes-three-main-background.php
+++ b/patterns/general-boxes-three-main-background.php
@@ -14,8 +14,8 @@
 <!-- /wp:spacer -->
 <!-- wp:columns {"align":"wide"} -->
 <div class="wp-block-columns alignwide">
-<!-- wp:column {"style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"}}},"backgroundColor":"base"} -->
-<div class="wp-block-column has-base-background-color has-background" style="padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px">
+<!-- wp:column {"style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"}}},"backgroundColor":"background"} -->
+<div class="wp-block-column has-background-background-color has-background" style="padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px">
 <!-- wp:heading {"level":3} -->
 <h3 id="sample-heading-1"><?php echo esc_html__( 'Sample Heading', 'frost' ); ?></h3>
 <!-- /wp:heading -->
@@ -31,8 +31,8 @@
 <!-- /wp:buttons -->
 </div>
 <!-- /wp:column -->
-<!-- wp:column {"style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"}}},"backgroundColor":"base"} -->
-<div class="wp-block-column has-base-background-color has-background" style="padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px">
+<!-- wp:column {"style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"}}},"backgroundColor":"background"} -->
+<div class="wp-block-column has-background-background-color has-background" style="padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px">
 <!-- wp:heading {"level":3} -->
 <h3 id="sample-heading-2"><?php echo esc_html__( 'Sample Heading', 'frost' ); ?></h3>
 <!-- /wp:heading -->
@@ -48,8 +48,8 @@
 <!-- /wp:buttons -->
 </div>
 <!-- /wp:column -->
-<!-- wp:column {"style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"}}},"backgroundColor":"base"} -->
-<div class="wp-block-column has-base-background-color has-background" style="padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px">
+<!-- wp:column {"style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"}}},"backgroundColor":"background"} -->
+<div class="wp-block-column has-background-background-color has-background" style="padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px">
 <!-- wp:heading {"level":3} -->
 <h3 id="sample-heading-3"><?php echo esc_html__( 'Sample Heading', 'frost' ); ?></h3>
 <!-- /wp:heading -->

--- a/patterns/general-boxes-three.php
+++ b/patterns/general-boxes-three.php
@@ -7,8 +7,8 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px"}}},"textColor":"base","layout":{"inherit":true}} -->
-<div class="wp-block-group alignfull has-base-color has-text-color" style="margin-top:0px">
+<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px"}}},"textColor":"background","layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull has-background-color has-text-color" style="margin-top:0px">
 <!-- wp:spacer {"height":100} -->
 <div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
@@ -24,8 +24,8 @@
 <!-- /wp:paragraph -->
 <!-- wp:buttons -->
 <div class="wp-block-buttons">
-<!-- wp:button {"style":{"border":{"radius":0}},"className":"is-style-fill-base"} -->
-<div class="wp-block-button is-style-fill-base"><a class="wp-block-button__link no-border-radius"><?php echo esc_html__( 'Learn More', 'frost' ); ?></a></div>
+<!-- wp:button {"style":{"border":{"radius":0}},"className":"is-style-fill-background"} -->
+<div class="wp-block-button is-style-fill-background"><a class="wp-block-button__link no-border-radius"><?php echo esc_html__( 'Learn More', 'frost' ); ?></a></div>
 <!-- /wp:button -->
 </div>
 <!-- /wp:buttons -->
@@ -41,8 +41,8 @@
 <!-- /wp:paragraph -->
 <!-- wp:buttons -->
 <div class="wp-block-buttons">
-<!-- wp:button {"style":{"border":{"radius":0}},"className":"is-style-fill-base"} -->
-<div class="wp-block-button is-style-fill-base"><a class="wp-block-button__link no-border-radius"><?php echo esc_html__( 'Learn More', 'frost' ); ?></a></div>
+<!-- wp:button {"style":{"border":{"radius":0}},"className":"is-style-fill-background"} -->
+<div class="wp-block-button is-style-fill-background"><a class="wp-block-button__link no-border-radius"><?php echo esc_html__( 'Learn More', 'frost' ); ?></a></div>
 <!-- /wp:button -->
 </div>
 <!-- /wp:buttons -->
@@ -58,8 +58,8 @@
 <!-- /wp:paragraph -->
 <!-- wp:buttons -->
 <div class="wp-block-buttons">
-<!-- wp:button {"style":{"border":{"radius":0}},"className":"is-style-fill-base"} -->
-<div class="wp-block-button is-style-fill-base"><a class="wp-block-button__link no-border-radius"><?php echo esc_html__( 'Learn More', 'frost' ); ?></a></div>
+<!-- wp:button {"style":{"border":{"radius":0}},"className":"is-style-fill-background"} -->
+<div class="wp-block-button is-style-fill-background"><a class="wp-block-button__link no-border-radius"><?php echo esc_html__( 'Learn More', 'frost' ); ?></a></div>
 <!-- /wp:button -->
 </div>
 <!-- /wp:buttons -->

--- a/patterns/general-boxes-three.php
+++ b/patterns/general-boxes-three.php
@@ -14,8 +14,8 @@
 <!-- /wp:spacer -->
 <!-- wp:columns {"align":"wide"} -->
 <div class="wp-block-columns alignwide">
-<!-- wp:column {"style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"}}},"backgroundColor":"main"} -->
-<div class="wp-block-column has-main-background-color has-background" style="padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px">
+<!-- wp:column {"style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"}}},"backgroundColor":"foreground"} -->
+<div class="wp-block-column has-foreground-background-color has-background" style="padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px">
 <!-- wp:heading {"level":3} -->
 <h3 id="sample-heading-1"><?php echo esc_html__( 'Sample Heading', 'frost' ); ?></h3>
 <!-- /wp:heading -->
@@ -31,8 +31,8 @@
 <!-- /wp:buttons -->
 </div>
 <!-- /wp:column -->
-<!-- wp:column {"style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"}}},"backgroundColor":"main"} -->
-<div class="wp-block-column has-main-background-color has-background" style="padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px">
+<!-- wp:column {"style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"}}},"backgroundColor":"foreground"} -->
+<div class="wp-block-column has-foreground-background-color has-background" style="padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px">
 <!-- wp:heading {"level":3} -->
 <h3 id="sample-heading-2"><?php echo esc_html__( 'Sample Heading', 'frost' ); ?></h3>
 <!-- /wp:heading -->
@@ -48,8 +48,8 @@
 <!-- /wp:buttons -->
 </div>
 <!-- /wp:column -->
-<!-- wp:column {"style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"}}},"backgroundColor":"main"} -->
-<div class="wp-block-column has-main-background-color has-background" style="padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px">
+<!-- wp:column {"style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"}}},"backgroundColor":"foreground"} -->
+<div class="wp-block-column has-foreground-background-color has-background" style="padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px">
 <!-- wp:heading {"level":3} -->
 <h3 id="sample-heading-3"><?php echo esc_html__( 'Sample Heading', 'frost' ); ?></h3>
 <!-- /wp:heading -->

--- a/patterns/general-boxes-two-main-background.php
+++ b/patterns/general-boxes-two-main-background.php
@@ -7,8 +7,8 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"main","layout":{"inherit":true}} -->
-<div class="wp-block-group alignfull has-main-background-color has-background" style="margin-top:0px">
+<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"foreground","layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull has-foreground-background-color has-background" style="margin-top:0px">
 <!-- wp:spacer {"height":100} -->
 <div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->

--- a/patterns/general-boxes-two-main-background.php
+++ b/patterns/general-boxes-two-main-background.php
@@ -14,8 +14,8 @@
 <!-- /wp:spacer -->
 <!-- wp:columns {"align":"wide"} -->
 <div class="wp-block-columns alignwide">
-<!-- wp:column {"style":{"spacing":{"padding":{"top":"60px","right":"60px","bottom":"60px","left":"60px"}}},"backgroundColor":"base"} -->
-<div class="wp-block-column has-base-background-color has-background" style="padding-top:60px;padding-right:60px;padding-bottom:60px;padding-left:60px">
+<!-- wp:column {"style":{"spacing":{"padding":{"top":"60px","right":"60px","bottom":"60px","left":"60px"}}},"backgroundColor":"background"} -->
+<div class="wp-block-column has-background-background-color has-background" style="padding-top:60px;padding-right:60px;padding-bottom:60px;padding-left:60px">
 <!-- wp:heading {"level":3,"fontSize":"large"} -->
 <h3 class="has-large-font-size" id="sample-heading-1"><?php echo esc_html__( 'Sample Heading', 'frost' ); ?></h3>
 <!-- /wp:heading -->
@@ -31,8 +31,8 @@
 <!-- /wp:buttons -->
 </div>
 <!-- /wp:column -->
-<!-- wp:column {"style":{"spacing":{"padding":{"top":"60px","right":"60px","bottom":"60px","left":"60px"}}},"backgroundColor":"base"} -->
-<div class="wp-block-column has-base-background-color has-background" style="padding-top:60px;padding-right:60px;padding-bottom:60px;padding-left:60px">
+<!-- wp:column {"style":{"spacing":{"padding":{"top":"60px","right":"60px","bottom":"60px","left":"60px"}}},"backgroundColor":"background"} -->
+<div class="wp-block-column has-background-background-color has-background" style="padding-top:60px;padding-right:60px;padding-bottom:60px;padding-left:60px">
 <!-- wp:heading {"level":3,"fontSize":"large"} -->
 <h3 class="has-large-font-size" id="sample-heading-2"><?php echo esc_html__( 'Sample Heading', 'frost' ); ?></h3>
 <!-- /wp:heading -->

--- a/patterns/general-boxes-two.php
+++ b/patterns/general-boxes-two.php
@@ -14,8 +14,8 @@
 <!-- /wp:spacer -->
 <!-- wp:columns {"align":"wide"} -->
 <div class="wp-block-columns alignwide">
-<!-- wp:column {"style":{"spacing":{"padding":{"top":"60px","right":"60px","bottom":"60px","left":"60px"}}},"backgroundColor":"main"} -->
-<div class="wp-block-column has-main-background-color has-background" style="padding-top:60px;padding-right:60px;padding-bottom:60px;padding-left:60px">
+<!-- wp:column {"style":{"spacing":{"padding":{"top":"60px","right":"60px","bottom":"60px","left":"60px"}}},"backgroundColor":"foreground"} -->
+<div class="wp-block-column has-foreground-background-color has-background" style="padding-top:60px;padding-right:60px;padding-bottom:60px;padding-left:60px">
 <!-- wp:heading {"level":3,"fontSize":"large"} -->
 <h3 class="has-large-font-size" id="sample-heading-1"><?php echo esc_html__( 'Sample Heading', 'frost' ); ?></h3>
 <!-- /wp:heading -->
@@ -31,8 +31,8 @@
 <!-- /wp:buttons -->
 </div>
 <!-- /wp:column -->
-<!-- wp:column {"style":{"spacing":{"padding":{"top":"60px","right":"60px","bottom":"60px","left":"60px"}}},"backgroundColor":"main"} -->
-<div class="wp-block-column has-main-background-color has-background" style="padding-top:60px;padding-right:60px;padding-bottom:60px;padding-left:60px">
+<!-- wp:column {"style":{"spacing":{"padding":{"top":"60px","right":"60px","bottom":"60px","left":"60px"}}},"backgroundColor":"foreground"} -->
+<div class="wp-block-column has-foreground-background-color has-background" style="padding-top:60px;padding-right:60px;padding-bottom:60px;padding-left:60px">
 <!-- wp:heading {"level":3,"fontSize":"large"} -->
 <h3 class="has-large-font-size" id="sample-heading-2"><?php echo esc_html__( 'Sample Heading', 'frost' ); ?></h3>
 <!-- /wp:heading -->

--- a/patterns/general-boxes-two.php
+++ b/patterns/general-boxes-two.php
@@ -7,8 +7,8 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px"}}},"textColor":"base","layout":{"inherit":true}} -->
-<div class="wp-block-group alignfull has-base-color has-text-color" style="margin-top:0px">
+<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px"}}},"textColor":"background","layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull has-background-color has-text-color" style="margin-top:0px">
 <!-- wp:spacer {"height":100} -->
 <div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
@@ -24,8 +24,8 @@
 <!-- /wp:paragraph -->
 <!-- wp:buttons -->
 <div class="wp-block-buttons">
-<!-- wp:button {"style":{"border":{"radius":0}},"className":"is-style-fill-base"} -->
-<div class="wp-block-button is-style-fill-base"><a class="wp-block-button__link no-border-radius"><?php echo esc_html__( 'Learn More', 'frost' ); ?></a></div>
+<!-- wp:button {"style":{"border":{"radius":0}},"className":"is-style-fill-background"} -->
+<div class="wp-block-button is-style-fill-background"><a class="wp-block-button__link no-border-radius"><?php echo esc_html__( 'Learn More', 'frost' ); ?></a></div>
 <!-- /wp:button -->
 </div>
 <!-- /wp:buttons -->
@@ -41,8 +41,8 @@
 <!-- /wp:paragraph -->
 <!-- wp:buttons -->
 <div class="wp-block-buttons">
-<!-- wp:button {"style":{"border":{"radius":0}},"className":"is-style-fill-base"} -->
-<div class="wp-block-button is-style-fill-base"><a class="wp-block-button__link no-border-radius"><?php echo esc_html__( 'Learn More', 'frost' ); ?></a></div>
+<!-- wp:button {"style":{"border":{"radius":0}},"className":"is-style-fill-background"} -->
+<div class="wp-block-button is-style-fill-background"><a class="wp-block-button__link no-border-radius"><?php echo esc_html__( 'Learn More', 'frost' ); ?></a></div>
 <!-- /wp:button -->
 </div>
 <!-- /wp:buttons -->

--- a/patterns/general-cta-button-main-background.php
+++ b/patterns/general-cta-button-main-background.php
@@ -7,8 +7,8 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"main","textColor":"base","layout":{"inherit":true}} -->
-<div class="wp-block-group alignfull has-base-color has-main-background-color has-text-color has-background" style="margin-top:0px">
+<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"main","textColor":"background","layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull has-background-color has-main-background-color has-text-color has-background" style="margin-top:0px">
 <!-- wp:spacer {"height":100} -->
 <div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
@@ -25,8 +25,8 @@
 <div class="wp-block-column is-vertically-aligned-center" style="flex-basis:40%">
 <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"right","orientation":"horizontal"}} -->
 <div class="wp-block-buttons">
-<!-- wp:button {"style":{"spacing":{"padding":{"top":"15px","bottom":"15px","left":"25px","right":"25px"}},"border":{"radius":"0px"}},"className":"is-style-fill-base"} -->
-<div class="wp-block-button is-style-fill-base"><a class="wp-block-button__link" style="border-radius:0px;padding-top:15px;padding-right:25px;padding-bottom:15px;padding-left:25px"><?php echo esc_html__( 'Let’s Get Started', 'frost' ); ?> →</a></div>
+<!-- wp:button {"style":{"spacing":{"padding":{"top":"15px","bottom":"15px","left":"25px","right":"25px"}},"border":{"radius":"0px"}},"className":"is-style-fill-background"} -->
+<div class="wp-block-button is-style-fill-background"><a class="wp-block-button__link" style="border-radius:0px;padding-top:15px;padding-right:25px;padding-bottom:15px;padding-left:25px"><?php echo esc_html__( 'Let’s Get Started', 'frost' ); ?> →</a></div>
 <!-- /wp:button -->
 </div>
 <!-- /wp:buttons -->

--- a/patterns/general-cta-button-main-background.php
+++ b/patterns/general-cta-button-main-background.php
@@ -7,8 +7,8 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"main","textColor":"background","layout":{"inherit":true}} -->
-<div class="wp-block-group alignfull has-background-color has-main-background-color has-text-color has-background" style="margin-top:0px">
+<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull has-background-color has-foreground-background-color has-text-color has-background" style="margin-top:0px">
 <!-- wp:spacer {"height":100} -->
 <div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->

--- a/patterns/general-cta-buttons-main-background.php
+++ b/patterns/general-cta-buttons-main-background.php
@@ -7,8 +7,8 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"main","textColor":"base","layout":{"inherit":true}} -->
-<div class="wp-block-group alignfull has-base-color has-main-background-color has-text-color has-background" style="margin-top:0px">
+<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"main","textColor":"background","layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull has-background-color has-main-background-color has-text-color has-background" style="margin-top:0px">
 <!-- wp:spacer {"height":100} -->
 <div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
@@ -25,11 +25,11 @@
 <div class="wp-block-column is-vertically-aligned-center" style="flex-basis:40%">
 <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"right","orientation":"horizontal"},"style":{"spacing":{"blockGap":"10px"}}} -->
 <div class="wp-block-buttons">
-<!-- wp:button {"style":{"border":{"radius":0}},"className":"large is-style-fill-base"} -->
-<div class="wp-block-button large is-style-fill-base"><a class="wp-block-button__link no-border-radius"><?php echo esc_html__( 'Get Started', 'frost' ); ?> →</a></div>
+<!-- wp:button {"style":{"border":{"radius":0}},"className":"large is-style-fill-background"} -->
+<div class="wp-block-button large is-style-fill-background"><a class="wp-block-button__link no-border-radius"><?php echo esc_html__( 'Get Started', 'frost' ); ?> →</a></div>
 <!-- /wp:button -->
-<!-- wp:button {"style":{"border":{"radius":0}},"className":"large is-style-outline-base"} -->
-<div class="wp-block-button large is-style-outline-base"><a class="wp-block-button__link no-border-radius"><?php echo esc_html__( 'Learn More', 'frost' ); ?></a></div>
+<!-- wp:button {"style":{"border":{"radius":0}},"className":"large is-style-outline-background"} -->
+<div class="wp-block-button large is-style-outline-background"><a class="wp-block-button__link no-border-radius"><?php echo esc_html__( 'Learn More', 'frost' ); ?></a></div>
 <!-- /wp:button -->
 </div>
 <!-- /wp:buttons -->

--- a/patterns/general-cta-buttons-main-background.php
+++ b/patterns/general-cta-buttons-main-background.php
@@ -7,8 +7,8 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"main","textColor":"background","layout":{"inherit":true}} -->
-<div class="wp-block-group alignfull has-background-color has-main-background-color has-text-color has-background" style="margin-top:0px">
+<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull has-background-color has-foreground-background-color has-text-color has-background" style="margin-top:0px">
 <!-- wp:spacer {"height":100} -->
 <div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->

--- a/patterns/general-cta-stacked-main-background.php
+++ b/patterns/general-cta-stacked-main-background.php
@@ -6,8 +6,8 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"main","textColor":"base","layout":{"inherit":true}} -->
-<div class="wp-block-group alignfull has-base-color has-main-background-color has-text-color has-background" style="margin-top:0px">
+<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"main","textColor":"background","layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull has-background-color has-main-background-color has-text-color has-background" style="margin-top:0px">
 <!-- wp:spacer {"height":100} -->
 <div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
@@ -19,8 +19,8 @@
 <!-- /wp:paragraph -->
 <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center"}} -->
 <div class="wp-block-buttons">
-<!-- wp:button {"className":"is-style-outline-base"} -->
-<div class="wp-block-button is-style-outline-base"><a class="wp-block-button__link"><?php echo esc_html__( 'Get in Touch', 'frost' ); ?> →</a></div>
+<!-- wp:button {"className":"is-style-outline-background"} -->
+<div class="wp-block-button is-style-outline-background"><a class="wp-block-button__link"><?php echo esc_html__( 'Get in Touch', 'frost' ); ?> →</a></div>
 <!-- /wp:button -->
 </div>
 <!-- /wp:buttons -->

--- a/patterns/general-cta-stacked-main-background.php
+++ b/patterns/general-cta-stacked-main-background.php
@@ -6,8 +6,8 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"main","textColor":"background","layout":{"inherit":true}} -->
-<div class="wp-block-group alignfull has-background-color has-main-background-color has-text-color has-background" style="margin-top:0px">
+<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull has-background-color has-foreground-background-color has-text-color has-background" style="margin-top:0px">
 <!-- wp:spacer {"height":100} -->
 <div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->

--- a/patterns/general-hero-one-column-main-background.php
+++ b/patterns/general-hero-one-column-main-background.php
@@ -6,8 +6,8 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"main","textColor":"base","layout":{"wideSize":"800px"}} -->
-<div class="wp-block-group alignfull has-base-color has-main-background-color has-text-color has-background" style="margin-top:0px">
+<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"main","textColor":"background","layout":{"wideSize":"800px"}} -->
+<div class="wp-block-group alignfull has-background-color has-main-background-color has-text-color has-background" style="margin-top:0px">
 <!-- wp:spacer {"height":100} -->
 <div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
@@ -25,11 +25,11 @@
 <!-- /wp:paragraph -->
 <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center","orientation":"horizontal"},"style":{"spacing":{"blockGap":"10px"}}} -->
 <div class="wp-block-buttons">
-<!-- wp:button {"style":{"border":{"radius":0}},"className":"is-style-fill-base"} -->
-<div class="wp-block-button is-style-fill-base"><a class="wp-block-button__link no-border-radius"><?php echo esc_html__( 'Get Started', 'frost' ); ?></a></div>
+<!-- wp:button {"style":{"border":{"radius":0}},"className":"is-style-fill-background"} -->
+<div class="wp-block-button is-style-fill-background"><a class="wp-block-button__link no-border-radius"><?php echo esc_html__( 'Get Started', 'frost' ); ?></a></div>
 <!-- /wp:button -->
-<!-- wp:button {"style":{"border":{"radius":0}},"className":"is-style-outline-base"} -->
-<div class="wp-block-button is-style-outline-base"><a class="wp-block-button__link no-border-radius"><?php echo esc_html__( 'Learn More', 'frost' ); ?></a></div>
+<!-- wp:button {"style":{"border":{"radius":0}},"className":"is-style-outline-background"} -->
+<div class="wp-block-button is-style-outline-background"><a class="wp-block-button__link no-border-radius"><?php echo esc_html__( 'Learn More', 'frost' ); ?></a></div>
 <!-- /wp:button -->
 </div>
 <!-- /wp:buttons -->

--- a/patterns/general-hero-one-column-main-background.php
+++ b/patterns/general-hero-one-column-main-background.php
@@ -6,8 +6,8 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"main","textColor":"background","layout":{"wideSize":"800px"}} -->
-<div class="wp-block-group alignfull has-background-color has-main-background-color has-text-color has-background" style="margin-top:0px">
+<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"foreground","textColor":"background","layout":{"wideSize":"800px"}} -->
+<div class="wp-block-group alignfull has-background-color has-foreground-background-color has-text-color has-background" style="margin-top:0px">
 <!-- wp:spacer {"height":100} -->
 <div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->

--- a/patterns/general-hero-three-columns-main-background.php
+++ b/patterns/general-hero-three-columns-main-background.php
@@ -7,8 +7,8 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"main","textColor":"background","layout":{"inherit":true}} -->
-<div class="wp-block-group alignfull has-background-color has-main-background-color has-text-color has-background" style="margin-top:0px">
+<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull has-background-color has-foreground-background-color has-text-color has-background" style="margin-top:0px">
 <!-- wp:spacer {"height":100} -->
 <div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->

--- a/patterns/general-hero-three-columns-main-background.php
+++ b/patterns/general-hero-three-columns-main-background.php
@@ -7,8 +7,8 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"main","textColor":"base","layout":{"inherit":true}} -->
-<div class="wp-block-group alignfull has-base-color has-main-background-color has-text-color has-background" style="margin-top:0px">
+<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"main","textColor":"background","layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull has-background-color has-main-background-color has-text-color has-background" style="margin-top:0px">
 <!-- wp:spacer {"height":100} -->
 <div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
@@ -36,8 +36,8 @@
 <!-- /wp:paragraph -->
 <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center","orientation":"horizontal"}} -->
 <div class="wp-block-buttons">
-<!-- wp:button {"style":{"border":{"radius":0}},"className":"is-style-outline-base"} -->
-<div class="wp-block-button is-style-outline-base"><a class="wp-block-button__link no-border-radius"><?php echo esc_html__( 'Learn More', 'frost' ); ?></a></div>
+<!-- wp:button {"style":{"border":{"radius":0}},"className":"is-style-outline-background"} -->
+<div class="wp-block-button is-style-outline-background"><a class="wp-block-button__link no-border-radius"><?php echo esc_html__( 'Learn More', 'frost' ); ?></a></div>
 <!-- /wp:button -->
 </div>
 <!-- /wp:buttons -->
@@ -56,8 +56,8 @@
 <!-- /wp:paragraph -->
 <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center","orientation":"horizontal"}} -->
 <div class="wp-block-buttons">
-<!-- wp:button {"style":{"border":{"radius":0}},"className":"is-style-outline-base"} -->
-<div class="wp-block-button is-style-outline-base"><a class="wp-block-button__link no-border-radius"><?php echo esc_html__( 'Learn More', 'frost' ); ?></a></div>
+<!-- wp:button {"style":{"border":{"radius":0}},"className":"is-style-outline-background"} -->
+<div class="wp-block-button is-style-outline-background"><a class="wp-block-button__link no-border-radius"><?php echo esc_html__( 'Learn More', 'frost' ); ?></a></div>
 <!-- /wp:button -->
 </div>
 <!-- /wp:buttons -->
@@ -76,8 +76,8 @@
 <!-- /wp:paragraph -->
 <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center","orientation":"horizontal"}} -->
 <div class="wp-block-buttons">
-<!-- wp:button {"style":{"border":{"radius":0}},"className":"is-style-outline-base"} -->
-<div class="wp-block-button is-style-outline-base"><a class="wp-block-button__link no-border-radius"><?php echo esc_html__( 'Learn More', 'frost' ); ?></a></div>
+<!-- wp:button {"style":{"border":{"radius":0}},"className":"is-style-outline-background"} -->
+<div class="wp-block-button is-style-outline-background"><a class="wp-block-button__link no-border-radius"><?php echo esc_html__( 'Learn More', 'frost' ); ?></a></div>
 <!-- /wp:button -->
 </div>
 <!-- /wp:buttons -->

--- a/patterns/general-hero-two-columns-main-background.php
+++ b/patterns/general-hero-two-columns-main-background.php
@@ -7,8 +7,8 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"main","textColor":"background","layout":{"inherit":true}} -->
-<div class="wp-block-group alignfull has-background-color has-main-background-color has-text-color has-background" style="margin-top:0px">
+<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull has-background-color has-foreground-background-color has-text-color has-background" style="margin-top:0px">
 <!-- wp:spacer {"height":100} -->
 <div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->

--- a/patterns/general-hero-two-columns-main-background.php
+++ b/patterns/general-hero-two-columns-main-background.php
@@ -7,8 +7,8 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"main","textColor":"base","layout":{"inherit":true}} -->
-<div class="wp-block-group alignfull has-base-color has-main-background-color has-text-color has-background" style="margin-top:0px">
+<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"main","textColor":"background","layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull has-background-color has-main-background-color has-text-color has-background" style="margin-top:0px">
 <!-- wp:spacer {"height":100} -->
 <div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
@@ -22,11 +22,11 @@
 <!-- /wp:paragraph -->
 <!-- wp:buttons {"style":{"spacing":{"blockGap":"10px"}}} -->
 <div class="wp-block-buttons">
-<!-- wp:button {"style":{"border":{"radius":0}},"className":"is-style-fill-base"} -->
-<div class="wp-block-button is-style-fill-base"><a class="wp-block-button__link no-border-radius"><?php echo esc_html__( 'Get Started', 'frost' ); ?></a></div>
+<!-- wp:button {"style":{"border":{"radius":0}},"className":"is-style-fill-background"} -->
+<div class="wp-block-button is-style-fill-background"><a class="wp-block-button__link no-border-radius"><?php echo esc_html__( 'Get Started', 'frost' ); ?></a></div>
 <!-- /wp:button -->
-<!-- wp:button {"style":{"border":{"radius":0}},"className":"is-style-outline-base"} -->
-<div class="wp-block-button is-style-outline-base"><a class="wp-block-button__link no-border-radius"><?php echo esc_html__( 'Learn More', 'frost' ); ?></a></div>
+<!-- wp:button {"style":{"border":{"radius":0}},"className":"is-style-outline-background"} -->
+<div class="wp-block-button is-style-outline-background"><a class="wp-block-button__link no-border-radius"><?php echo esc_html__( 'Learn More', 'frost' ); ?></a></div>
 <!-- /wp:button -->
 </div>
 <!-- /wp:buttons -->

--- a/patterns/general-podcast-main-background.php
+++ b/patterns/general-podcast-main-background.php
@@ -7,8 +7,8 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"main","textColor":"base","layout":{"inherit":true}} -->
-<div class="wp-block-group alignfull has-base-color has-main-background-color has-text-color has-background" style="margin-top:0px">
+<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"main","textColor":"background","layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull has-background-color has-main-background-color has-text-color has-background" style="margin-top:0px">
 <!-- wp:spacer {"height":100} -->
 <div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
@@ -34,17 +34,17 @@
 <!-- /wp:audio -->
 <!-- wp:buttons {"style":{"spacing":{"blockGap":"10px"}}} -->
 <div class="wp-block-buttons">
-<!-- wp:button {"className":"is-style-outline-base"} -->
-<div class="wp-block-button is-style-outline-base"><a class="wp-block-button__link" href="#">Apple Podcasts</a></div>
+<!-- wp:button {"className":"is-style-outline-background"} -->
+<div class="wp-block-button is-style-outline-background"><a class="wp-block-button__link" href="#">Apple Podcasts</a></div>
 <!-- /wp:button -->
-<!-- wp:button {"className":"is-style-outline-base"} -->
-<div class="wp-block-button is-style-outline-base"><a class="wp-block-button__link" href="#">Google Podcasts</a></div>
+<!-- wp:button {"className":"is-style-outline-background"} -->
+<div class="wp-block-button is-style-outline-background"><a class="wp-block-button__link" href="#">Google Podcasts</a></div>
 <!-- /wp:button -->
-<!-- wp:button {"className":"is-style-outline-base"} -->
-<div class="wp-block-button is-style-outline-base"><a class="wp-block-button__link" href="#">Spotify</a></div>
+<!-- wp:button {"className":"is-style-outline-background"} -->
+<div class="wp-block-button is-style-outline-background"><a class="wp-block-button__link" href="#">Spotify</a></div>
 <!-- /wp:button -->
-<!-- wp:button {"className":"is-style-outline-base"} -->
-<div class="wp-block-button is-style-outline-base"><a class="wp-block-button__link" href="#">Stitcher</a></div>
+<!-- wp:button {"className":"is-style-outline-background"} -->
+<div class="wp-block-button is-style-outline-background"><a class="wp-block-button__link" href="#">Stitcher</a></div>
 <!-- /wp:button -->
 </div>
 <!-- /wp:buttons -->

--- a/patterns/general-podcast-main-background.php
+++ b/patterns/general-podcast-main-background.php
@@ -7,8 +7,8 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"main","textColor":"background","layout":{"inherit":true}} -->
-<div class="wp-block-group alignfull has-background-color has-main-background-color has-text-color has-background" style="margin-top:0px">
+<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull has-background-color has-foreground-background-color has-text-color has-background" style="margin-top:0px">
 <!-- wp:spacer {"height":100} -->
 <div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->

--- a/patterns/general-portfolio-main-background.php
+++ b/patterns/general-portfolio-main-background.php
@@ -7,8 +7,8 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"main","textColor":"background","layout":{"inherit":true}} -->
-<div class="wp-block-group alignfull has-background-color has-main-background-color has-text-color has-background has-link-color" style="margin-top:0px">
+<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull has-background-color has-foreground-background-color has-text-color has-background has-link-color" style="margin-top:0px">
 <!-- wp:spacer {"height":100} -->
 <div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->

--- a/patterns/general-portfolio-main-background.php
+++ b/patterns/general-portfolio-main-background.php
@@ -7,8 +7,8 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|base"}}},"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"main","textColor":"base","layout":{"inherit":true}} -->
-<div class="wp-block-group alignfull has-base-color has-main-background-color has-text-color has-background has-link-color" style="margin-top:0px">
+<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"main","textColor":"background","layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull has-background-color has-main-background-color has-text-color has-background has-link-color" style="margin-top:0px">
 <!-- wp:spacer {"height":100} -->
 <div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->

--- a/patterns/general-pricing-four-columns-main-background.php
+++ b/patterns/general-pricing-four-columns-main-background.php
@@ -7,8 +7,8 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"main","textColor":"background","layout":{"inherit":true}} -->
-<div class="wp-block-group alignfull has-background-color has-main-background-color has-text-color has-background" style="margin-top:0px">
+<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull has-background-color has-foreground-background-color has-text-color has-background" style="margin-top:0px">
 <!-- wp:spacer -->
 <div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
@@ -22,8 +22,8 @@
 <div class="wp-block-columns alignwide has-smaller-left-margin">
 <!-- wp:column {"style":{"spacing":{"blockGap":"0px"}}} -->
 <div class="wp-block-column">
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"background","textColor":"main"} -->
-<div class="wp-block-group has-main-color has-background-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"background","textColor":"foreground"} -->
+<div class="wp-block-group has-foreground-color has-background-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
 <!-- wp:heading {"textAlign":"center","level":4} -->
 <h4 class="has-text-align-center" id="personal-95"><?php echo esc_html__( 'Personal', 'frost' ); ?> - $95</h4>
 <!-- /wp:heading -->
@@ -63,8 +63,8 @@
 <!-- /wp:separator -->
 <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"40px"}}}} -->
 <div class="wp-block-buttons" style="margin-top:40px">
-<!-- wp:button {"backgroundColor":"background","textColor":"main"} -->
-<div class="wp-block-button"><a class="wp-block-button__link has-main-color has-background-background-color has-text-color has-background"><?php echo esc_html__( 'Sign Up Now', 'frost' ); ?></a></div>
+<!-- wp:button {"backgroundColor":"background","textColor":"foreground"} -->
+<div class="wp-block-button"><a class="wp-block-button__link has-foreground-color has-background-background-color has-text-color has-background"><?php echo esc_html__( 'Sign Up Now', 'frost' ); ?></a></div>
 <!-- /wp:button -->
 </div>
 <!-- /wp:buttons -->
@@ -74,8 +74,8 @@
 <!-- /wp:column -->
 <!-- wp:column {"style":{"spacing":{"blockGap":"0px"}}} -->
 <div class="wp-block-column">
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"background","textColor":"main"} -->
-<div class="wp-block-group has-main-color has-background-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"background","textColor":"foreground"} -->
+<div class="wp-block-group has-foreground-color has-background-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
 <!-- wp:heading {"textAlign":"center","level":4} -->
 <h4 class="has-text-align-center" id="personal-95"><?php echo esc_html__( 'Professional', 'frost' ); ?> - $295</h4>
 <!-- /wp:heading -->
@@ -115,8 +115,8 @@
 <!-- /wp:separator -->
 <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"40px"}}}} -->
 <div class="wp-block-buttons" style="margin-top:40px">
-<!-- wp:button {"backgroundColor":"background","textColor":"main"} -->
-<div class="wp-block-button"><a class="wp-block-button__link has-main-color has-background-background-color has-text-color has-background"><?php echo esc_html__( 'Sign Up Now', 'frost' ); ?></a></div>
+<!-- wp:button {"backgroundColor":"background","textColor":"foreground"} -->
+<div class="wp-block-button"><a class="wp-block-button__link has-foreground-color has-background-background-color has-text-color has-background"><?php echo esc_html__( 'Sign Up Now', 'frost' ); ?></a></div>
 <!-- /wp:button -->
 </div>
 <!-- /wp:buttons -->
@@ -126,8 +126,8 @@
 <!-- /wp:column -->
 <!-- wp:column {"style":{"spacing":{"blockGap":"0px"}}} -->
 <div class="wp-block-column">
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"background","textColor":"main"} -->
-<div class="wp-block-group has-main-color has-background-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"background","textColor":"foreground"} -->
+<div class="wp-block-group has-foreground-color has-background-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
 <!-- wp:heading {"textAlign":"center","level":4} -->
 <h4 class="has-text-align-center" id="personal-95"><?php echo esc_html__( 'Enterprise', 'frost' ); ?> - $495</h4>
 <!-- /wp:heading -->
@@ -167,8 +167,8 @@
 <!-- /wp:separator -->
 <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"40px"}}}} -->
 <div class="wp-block-buttons" style="margin-top:40px">
-<!-- wp:button {"backgroundColor":"background","textColor":"main"} -->
-<div class="wp-block-button"><a class="wp-block-button__link has-main-color has-background-background-color has-text-color has-background"><?php echo esc_html__( 'Sign Up Now', 'frost' ); ?></a></div>
+<!-- wp:button {"backgroundColor":"background","textColor":"foreground"} -->
+<div class="wp-block-button"><a class="wp-block-button__link has-foreground-color has-background-background-color has-text-color has-background"><?php echo esc_html__( 'Sign Up Now', 'frost' ); ?></a></div>
 <!-- /wp:button -->
 </div>
 <!-- /wp:buttons -->
@@ -178,8 +178,8 @@
 <!-- /wp:column -->
 <!-- wp:column {"style":{"spacing":{"blockGap":"0px"}}} -->
 <div class="wp-block-column">
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"background","textColor":"main"} -->
-<div class="wp-block-group has-main-color has-background-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"background","textColor":"foreground"} -->
+<div class="wp-block-group has-foreground-color has-background-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
 <!-- wp:heading {"textAlign":"center","level":4} -->
 <h4 class="has-text-align-center" id="personal-95"><?php echo esc_html__( 'Ultimate', 'frost' ); ?> - $995</h4>
 <!-- /wp:heading -->
@@ -219,8 +219,8 @@
 <!-- /wp:separator -->
 <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"40px"}}}} -->
 <div class="wp-block-buttons" style="margin-top:40px">
-<!-- wp:button {"backgroundColor":"background","textColor":"main"} -->
-<div class="wp-block-button"><a class="wp-block-button__link has-main-color has-background-background-color has-text-color has-background"><?php echo esc_html__( 'Sign Up Now', 'frost' ); ?></a></div>
+<!-- wp:button {"backgroundColor":"background","textColor":"foreground"} -->
+<div class="wp-block-button"><a class="wp-block-button__link has-foreground-color has-background-background-color has-text-color has-background"><?php echo esc_html__( 'Sign Up Now', 'frost' ); ?></a></div>
 <!-- /wp:button -->
 </div>
 <!-- /wp:buttons -->

--- a/patterns/general-pricing-four-columns-main-background.php
+++ b/patterns/general-pricing-four-columns-main-background.php
@@ -7,8 +7,8 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"main","textColor":"base","layout":{"inherit":true}} -->
-<div class="wp-block-group alignfull has-base-color has-main-background-color has-text-color has-background" style="margin-top:0px">
+<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"main","textColor":"background","layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull has-background-color has-main-background-color has-text-color has-background" style="margin-top:0px">
 <!-- wp:spacer -->
 <div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
@@ -22,49 +22,49 @@
 <div class="wp-block-columns alignwide has-smaller-left-margin">
 <!-- wp:column {"style":{"spacing":{"blockGap":"0px"}}} -->
 <div class="wp-block-column">
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"base","textColor":"main"} -->
-<div class="wp-block-group has-main-color has-base-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"background","textColor":"main"} -->
+<div class="wp-block-group has-main-color has-background-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
 <!-- wp:heading {"textAlign":"center","level":4} -->
 <h4 class="has-text-align-center" id="personal-95"><?php echo esc_html__( 'Personal', 'frost' ); ?> - $95</h4>
 <!-- /wp:heading -->
 </div>
 <!-- /wp:group -->
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"},"blockGap":"10px"},"border":{"width":"1px","style":"solid"}},"borderColor":"base"} -->
-<div class="wp-block-group has-border-color has-base-border-color" style="border-style:solid;border-width:1px;padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px">
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"},"blockGap":"10px"},"border":{"width":"1px","style":"solid"}},"borderColor":"background"} -->
+<div class="wp-block-group has-border-color has-background-border-color" style="border-style:solid;border-width:1px;padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px">
 <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 <p class="has-text-align-center has-small-font-size"><?php echo esc_html__( 'Feature Item', 'frost' ); ?></p>
 <!-- /wp:paragraph -->
-<!-- wp:separator {"backgroundColor":"base","className":"is-style-wide"} -->
-<hr class="wp-block-separator has-text-color has-base-color has-alpha-channel-opacity has-base-background-color has-background is-style-wide"/>
+<!-- wp:separator {"backgroundColor":"background","className":"is-style-wide"} -->
+<hr class="wp-block-separator has-text-color has-background-color has-alpha-channel-opacity has-background-background-color has-background is-style-wide"/>
 <!-- /wp:separator -->
 <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 <p class="has-text-align-center has-small-font-size"><?php echo esc_html__( 'Feature Item', 'frost' ); ?></p>
 <!-- /wp:paragraph -->
-<!-- wp:separator {"backgroundColor":"base","className":"is-style-wide"} -->
-<hr class="wp-block-separator has-text-color has-base-color has-alpha-channel-opacity has-base-background-color has-background is-style-wide"/>
+<!-- wp:separator {"backgroundColor":"background","className":"is-style-wide"} -->
+<hr class="wp-block-separator has-text-color has-background-color has-alpha-channel-opacity has-background-background-color has-background is-style-wide"/>
 <!-- /wp:separator -->
 <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 <p class="has-text-align-center has-small-font-size"><?php echo esc_html__( 'Feature Item', 'frost' ); ?></p>
 <!-- /wp:paragraph -->
-<!-- wp:separator {"backgroundColor":"base","className":"is-style-wide"} -->
-<hr class="wp-block-separator has-text-color has-base-color has-alpha-channel-opacity has-base-background-color has-background is-style-wide"/>
+<!-- wp:separator {"backgroundColor":"background","className":"is-style-wide"} -->
+<hr class="wp-block-separator has-text-color has-background-color has-alpha-channel-opacity has-background-background-color has-background is-style-wide"/>
 <!-- /wp:separator -->
 <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 <p class="has-text-align-center has-small-font-size"><?php echo esc_html__( 'Feature Item', 'frost' ); ?></p>
 <!-- /wp:paragraph -->
-<!-- wp:separator {"backgroundColor":"base","className":"is-style-wide"} -->
-<hr class="wp-block-separator has-text-color has-base-color has-alpha-channel-opacity has-base-background-color has-background is-style-wide"/>
+<!-- wp:separator {"backgroundColor":"background","className":"is-style-wide"} -->
+<hr class="wp-block-separator has-text-color has-background-color has-alpha-channel-opacity has-background-background-color has-background is-style-wide"/>
 <!-- /wp:separator -->
 <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 <p class="has-text-align-center has-small-font-size"><?php echo esc_html__( 'Feature Item', 'frost' ); ?></p>
 <!-- /wp:paragraph -->
-<!-- wp:separator {"backgroundColor":"base","className":"is-style-wide"} -->
-<hr class="wp-block-separator has-text-color has-base-color has-alpha-channel-opacity has-base-background-color has-background is-style-wide"/>
+<!-- wp:separator {"backgroundColor":"background","className":"is-style-wide"} -->
+<hr class="wp-block-separator has-text-color has-background-color has-alpha-channel-opacity has-background-background-color has-background is-style-wide"/>
 <!-- /wp:separator -->
 <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"40px"}}}} -->
 <div class="wp-block-buttons" style="margin-top:40px">
-<!-- wp:button {"backgroundColor":"base","textColor":"main"} -->
-<div class="wp-block-button"><a class="wp-block-button__link has-main-color has-base-background-color has-text-color has-background"><?php echo esc_html__( 'Sign Up Now', 'frost' ); ?></a></div>
+<!-- wp:button {"backgroundColor":"background","textColor":"main"} -->
+<div class="wp-block-button"><a class="wp-block-button__link has-main-color has-background-background-color has-text-color has-background"><?php echo esc_html__( 'Sign Up Now', 'frost' ); ?></a></div>
 <!-- /wp:button -->
 </div>
 <!-- /wp:buttons -->
@@ -74,49 +74,49 @@
 <!-- /wp:column -->
 <!-- wp:column {"style":{"spacing":{"blockGap":"0px"}}} -->
 <div class="wp-block-column">
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"base","textColor":"main"} -->
-<div class="wp-block-group has-main-color has-base-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"background","textColor":"main"} -->
+<div class="wp-block-group has-main-color has-background-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
 <!-- wp:heading {"textAlign":"center","level":4} -->
 <h4 class="has-text-align-center" id="personal-95"><?php echo esc_html__( 'Professional', 'frost' ); ?> - $295</h4>
 <!-- /wp:heading -->
 </div>
 <!-- /wp:group -->
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"},"blockGap":"10px"},"border":{"width":"1px","style":"solid"}},"borderColor":"base"} -->
-<div class="wp-block-group has-border-color has-base-border-color" style="border-style:solid;border-width:1px;padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px">
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"},"blockGap":"10px"},"border":{"width":"1px","style":"solid"}},"borderColor":"background"} -->
+<div class="wp-block-group has-border-color has-background-border-color" style="border-style:solid;border-width:1px;padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px">
 <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 <p class="has-text-align-center has-small-font-size"><?php echo esc_html__( 'Feature Item', 'frost' ); ?></p>
 <!-- /wp:paragraph -->
-<!-- wp:separator {"backgroundColor":"base","className":"is-style-wide"} -->
-<hr class="wp-block-separator has-text-color has-base-color has-alpha-channel-opacity has-base-background-color has-background is-style-wide"/>
+<!-- wp:separator {"backgroundColor":"background","className":"is-style-wide"} -->
+<hr class="wp-block-separator has-text-color has-background-color has-alpha-channel-opacity has-background-background-color has-background is-style-wide"/>
 <!-- /wp:separator -->
 <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 <p class="has-text-align-center has-small-font-size"><?php echo esc_html__( 'Feature Item', 'frost' ); ?></p>
 <!-- /wp:paragraph -->
-<!-- wp:separator {"backgroundColor":"base","className":"is-style-wide"} -->
-<hr class="wp-block-separator has-text-color has-base-color has-alpha-channel-opacity has-base-background-color has-background is-style-wide"/>
+<!-- wp:separator {"backgroundColor":"background","className":"is-style-wide"} -->
+<hr class="wp-block-separator has-text-color has-background-color has-alpha-channel-opacity has-background-background-color has-background is-style-wide"/>
 <!-- /wp:separator -->
 <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 <p class="has-text-align-center has-small-font-size"><?php echo esc_html__( 'Feature Item', 'frost' ); ?></p>
 <!-- /wp:paragraph -->
-<!-- wp:separator {"backgroundColor":"base","className":"is-style-wide"} -->
-<hr class="wp-block-separator has-text-color has-base-color has-alpha-channel-opacity has-base-background-color has-background is-style-wide"/>
+<!-- wp:separator {"backgroundColor":"background","className":"is-style-wide"} -->
+<hr class="wp-block-separator has-text-color has-background-color has-alpha-channel-opacity has-background-background-color has-background is-style-wide"/>
 <!-- /wp:separator -->
 <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 <p class="has-text-align-center has-small-font-size"><?php echo esc_html__( 'Feature Item', 'frost' ); ?></p>
 <!-- /wp:paragraph -->
-<!-- wp:separator {"backgroundColor":"base","className":"is-style-wide"} -->
-<hr class="wp-block-separator has-text-color has-base-color has-alpha-channel-opacity has-base-background-color has-background is-style-wide"/>
+<!-- wp:separator {"backgroundColor":"background","className":"is-style-wide"} -->
+<hr class="wp-block-separator has-text-color has-background-color has-alpha-channel-opacity has-background-background-color has-background is-style-wide"/>
 <!-- /wp:separator -->
 <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 <p class="has-text-align-center has-small-font-size"><?php echo esc_html__( 'Feature Item', 'frost' ); ?></p>
 <!-- /wp:paragraph -->
-<!-- wp:separator {"backgroundColor":"base","className":"is-style-wide"} -->
-<hr class="wp-block-separator has-text-color has-base-color has-alpha-channel-opacity has-base-background-color has-background is-style-wide"/>
+<!-- wp:separator {"backgroundColor":"background","className":"is-style-wide"} -->
+<hr class="wp-block-separator has-text-color has-background-color has-alpha-channel-opacity has-background-background-color has-background is-style-wide"/>
 <!-- /wp:separator -->
 <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"40px"}}}} -->
 <div class="wp-block-buttons" style="margin-top:40px">
-<!-- wp:button {"backgroundColor":"base","textColor":"main"} -->
-<div class="wp-block-button"><a class="wp-block-button__link has-main-color has-base-background-color has-text-color has-background"><?php echo esc_html__( 'Sign Up Now', 'frost' ); ?></a></div>
+<!-- wp:button {"backgroundColor":"background","textColor":"main"} -->
+<div class="wp-block-button"><a class="wp-block-button__link has-main-color has-background-background-color has-text-color has-background"><?php echo esc_html__( 'Sign Up Now', 'frost' ); ?></a></div>
 <!-- /wp:button -->
 </div>
 <!-- /wp:buttons -->
@@ -126,49 +126,49 @@
 <!-- /wp:column -->
 <!-- wp:column {"style":{"spacing":{"blockGap":"0px"}}} -->
 <div class="wp-block-column">
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"base","textColor":"main"} -->
-<div class="wp-block-group has-main-color has-base-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"background","textColor":"main"} -->
+<div class="wp-block-group has-main-color has-background-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
 <!-- wp:heading {"textAlign":"center","level":4} -->
 <h4 class="has-text-align-center" id="personal-95"><?php echo esc_html__( 'Enterprise', 'frost' ); ?> - $495</h4>
 <!-- /wp:heading -->
 </div>
 <!-- /wp:group -->
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"},"blockGap":"10px"},"border":{"width":"1px","style":"solid"}},"borderColor":"base"} -->
-<div class="wp-block-group has-border-color has-base-border-color" style="border-style:solid;border-width:1px;padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px">
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"},"blockGap":"10px"},"border":{"width":"1px","style":"solid"}},"borderColor":"background"} -->
+<div class="wp-block-group has-border-color has-background-border-color" style="border-style:solid;border-width:1px;padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px">
 <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 <p class="has-text-align-center has-small-font-size"><?php echo esc_html__( 'Feature Item', 'frost' ); ?></p>
 <!-- /wp:paragraph -->
-<!-- wp:separator {"backgroundColor":"base","className":"is-style-wide"} -->
-<hr class="wp-block-separator has-text-color has-base-color has-alpha-channel-opacity has-base-background-color has-background is-style-wide"/>
+<!-- wp:separator {"backgroundColor":"background","className":"is-style-wide"} -->
+<hr class="wp-block-separator has-text-color has-background-color has-alpha-channel-opacity has-background-background-color has-background is-style-wide"/>
 <!-- /wp:separator -->
 <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 <p class="has-text-align-center has-small-font-size"><?php echo esc_html__( 'Feature Item', 'frost' ); ?></p>
 <!-- /wp:paragraph -->
-<!-- wp:separator {"backgroundColor":"base","className":"is-style-wide"} -->
-<hr class="wp-block-separator has-text-color has-base-color has-alpha-channel-opacity has-base-background-color has-background is-style-wide"/>
+<!-- wp:separator {"backgroundColor":"background","className":"is-style-wide"} -->
+<hr class="wp-block-separator has-text-color has-background-color has-alpha-channel-opacity has-background-background-color has-background is-style-wide"/>
 <!-- /wp:separator -->
 <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 <p class="has-text-align-center has-small-font-size"><?php echo esc_html__( 'Feature Item', 'frost' ); ?></p>
 <!-- /wp:paragraph -->
-<!-- wp:separator {"backgroundColor":"base","className":"is-style-wide"} -->
-<hr class="wp-block-separator has-text-color has-base-color has-alpha-channel-opacity has-base-background-color has-background is-style-wide"/>
+<!-- wp:separator {"backgroundColor":"background","className":"is-style-wide"} -->
+<hr class="wp-block-separator has-text-color has-background-color has-alpha-channel-opacity has-background-background-color has-background is-style-wide"/>
 <!-- /wp:separator -->
 <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 <p class="has-text-align-center has-small-font-size"><?php echo esc_html__( 'Feature Item', 'frost' ); ?></p>
 <!-- /wp:paragraph -->
-<!-- wp:separator {"backgroundColor":"base","className":"is-style-wide"} -->
-<hr class="wp-block-separator has-text-color has-base-color has-alpha-channel-opacity has-base-background-color has-background is-style-wide"/>
+<!-- wp:separator {"backgroundColor":"background","className":"is-style-wide"} -->
+<hr class="wp-block-separator has-text-color has-background-color has-alpha-channel-opacity has-background-background-color has-background is-style-wide"/>
 <!-- /wp:separator -->
 <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 <p class="has-text-align-center has-small-font-size"><?php echo esc_html__( 'Feature Item', 'frost' ); ?></p>
 <!-- /wp:paragraph -->
-<!-- wp:separator {"backgroundColor":"base","className":"is-style-wide"} -->
-<hr class="wp-block-separator has-text-color has-base-color has-alpha-channel-opacity has-base-background-color has-background is-style-wide"/>
+<!-- wp:separator {"backgroundColor":"background","className":"is-style-wide"} -->
+<hr class="wp-block-separator has-text-color has-background-color has-alpha-channel-opacity has-background-background-color has-background is-style-wide"/>
 <!-- /wp:separator -->
 <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"40px"}}}} -->
 <div class="wp-block-buttons" style="margin-top:40px">
-<!-- wp:button {"backgroundColor":"base","textColor":"main"} -->
-<div class="wp-block-button"><a class="wp-block-button__link has-main-color has-base-background-color has-text-color has-background"><?php echo esc_html__( 'Sign Up Now', 'frost' ); ?></a></div>
+<!-- wp:button {"backgroundColor":"background","textColor":"main"} -->
+<div class="wp-block-button"><a class="wp-block-button__link has-main-color has-background-background-color has-text-color has-background"><?php echo esc_html__( 'Sign Up Now', 'frost' ); ?></a></div>
 <!-- /wp:button -->
 </div>
 <!-- /wp:buttons -->
@@ -178,49 +178,49 @@
 <!-- /wp:column -->
 <!-- wp:column {"style":{"spacing":{"blockGap":"0px"}}} -->
 <div class="wp-block-column">
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"base","textColor":"main"} -->
-<div class="wp-block-group has-main-color has-base-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"background","textColor":"main"} -->
+<div class="wp-block-group has-main-color has-background-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
 <!-- wp:heading {"textAlign":"center","level":4} -->
 <h4 class="has-text-align-center" id="personal-95"><?php echo esc_html__( 'Ultimate', 'frost' ); ?> - $995</h4>
 <!-- /wp:heading -->
 </div>
 <!-- /wp:group -->
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"},"blockGap":"10px"},"border":{"width":"1px","style":"solid"}},"borderColor":"base"} -->
-<div class="wp-block-group has-border-color has-base-border-color" style="border-style:solid;border-width:1px;padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px">
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"},"blockGap":"10px"},"border":{"width":"1px","style":"solid"}},"borderColor":"background"} -->
+<div class="wp-block-group has-border-color has-background-border-color" style="border-style:solid;border-width:1px;padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px">
 <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 <p class="has-text-align-center has-small-font-size"><?php echo esc_html__( 'Feature Item', 'frost' ); ?></p>
 <!-- /wp:paragraph -->
-<!-- wp:separator {"backgroundColor":"base","className":"is-style-wide"} -->
-<hr class="wp-block-separator has-text-color has-base-color has-alpha-channel-opacity has-base-background-color has-background is-style-wide"/>
+<!-- wp:separator {"backgroundColor":"background","className":"is-style-wide"} -->
+<hr class="wp-block-separator has-text-color has-background-color has-alpha-channel-opacity has-background-background-color has-background is-style-wide"/>
 <!-- /wp:separator -->
 <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 <p class="has-text-align-center has-small-font-size"><?php echo esc_html__( 'Feature Item', 'frost' ); ?></p>
 <!-- /wp:paragraph -->
-<!-- wp:separator {"backgroundColor":"base","className":"is-style-wide"} -->
-<hr class="wp-block-separator has-text-color has-base-color has-alpha-channel-opacity has-base-background-color has-background is-style-wide"/>
+<!-- wp:separator {"backgroundColor":"background","className":"is-style-wide"} -->
+<hr class="wp-block-separator has-text-color has-background-color has-alpha-channel-opacity has-background-background-color has-background is-style-wide"/>
 <!-- /wp:separator -->
 <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 <p class="has-text-align-center has-small-font-size"><?php echo esc_html__( 'Feature Item', 'frost' ); ?></p>
 <!-- /wp:paragraph -->
-<!-- wp:separator {"backgroundColor":"base","className":"is-style-wide"} -->
-<hr class="wp-block-separator has-text-color has-base-color has-alpha-channel-opacity has-base-background-color has-background is-style-wide"/>
+<!-- wp:separator {"backgroundColor":"background","className":"is-style-wide"} -->
+<hr class="wp-block-separator has-text-color has-background-color has-alpha-channel-opacity has-background-background-color has-background is-style-wide"/>
 <!-- /wp:separator -->
 <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 <p class="has-text-align-center has-small-font-size"><?php echo esc_html__( 'Feature Item', 'frost' ); ?></p>
 <!-- /wp:paragraph -->
-<!-- wp:separator {"backgroundColor":"base","className":"is-style-wide"} -->
-<hr class="wp-block-separator has-text-color has-base-color has-alpha-channel-opacity has-base-background-color has-background is-style-wide"/>
+<!-- wp:separator {"backgroundColor":"background","className":"is-style-wide"} -->
+<hr class="wp-block-separator has-text-color has-background-color has-alpha-channel-opacity has-background-background-color has-background is-style-wide"/>
 <!-- /wp:separator -->
 <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 <p class="has-text-align-center has-small-font-size"><?php echo esc_html__( 'Feature Item', 'frost' ); ?></p>
 <!-- /wp:paragraph -->
-<!-- wp:separator {"backgroundColor":"base","className":"is-style-wide"} -->
-<hr class="wp-block-separator has-text-color has-base-color has-alpha-channel-opacity has-base-background-color has-background is-style-wide"/>
+<!-- wp:separator {"backgroundColor":"background","className":"is-style-wide"} -->
+<hr class="wp-block-separator has-text-color has-background-color has-alpha-channel-opacity has-background-background-color has-background is-style-wide"/>
 <!-- /wp:separator -->
 <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"40px"}}}} -->
 <div class="wp-block-buttons" style="margin-top:40px">
-<!-- wp:button {"backgroundColor":"base","textColor":"main"} -->
-<div class="wp-block-button"><a class="wp-block-button__link has-main-color has-base-background-color has-text-color has-background"><?php echo esc_html__( 'Sign Up Now', 'frost' ); ?></a></div>
+<!-- wp:button {"backgroundColor":"background","textColor":"main"} -->
+<div class="wp-block-button"><a class="wp-block-button__link has-main-color has-background-background-color has-text-color has-background"><?php echo esc_html__( 'Sign Up Now', 'frost' ); ?></a></div>
 <!-- /wp:button -->
 </div>
 <!-- /wp:buttons -->

--- a/patterns/general-pricing-four-columns.php
+++ b/patterns/general-pricing-four-columns.php
@@ -22,15 +22,15 @@
 <div class="wp-block-columns alignwide has-smaller-left-margin">
 <!-- wp:column {"style":{"spacing":{"blockGap":"0px"}}} -->
 <div class="wp-block-column">
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"main","textColor":"background"} -->
-<div class="wp-block-group has-background-color has-main-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"foreground","textColor":"background"} -->
+<div class="wp-block-group has-background-color has-foreground-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
 <!-- wp:heading {"textAlign":"center","level":4} -->
 <h4 class="has-text-align-center" id="personal-95"><?php echo esc_html__( 'Personal', 'frost' ); ?> - $95</h4>
 <!-- /wp:heading -->
 </div>
 <!-- /wp:group -->
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"},"blockGap":"10px"},"border":{"width":"1px","style":"solid"}},"borderColor":"main"} -->
-<div class="wp-block-group has-border-color has-main-border-color" style="border-style:solid;border-width:1px;padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px">
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"},"blockGap":"10px"},"border":{"width":"1px","style":"solid"}},"borderColor":"foreground"} -->
+<div class="wp-block-group has-border-color has-foreground-border-color" style="border-style:solid;border-width:1px;padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px">
 <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 <p class="has-text-align-center has-small-font-size"><?php echo esc_html__( 'Feature Item', 'frost' ); ?></p>
 <!-- /wp:paragraph -->
@@ -74,15 +74,15 @@
 <!-- /wp:column -->
 <!-- wp:column {"style":{"spacing":{"blockGap":"0px"}}} -->
 <div class="wp-block-column">
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"main","textColor":"background"} -->
-<div class="wp-block-group has-background-color has-main-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"foreground","textColor":"background"} -->
+<div class="wp-block-group has-background-color has-foreground-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
 <!-- wp:heading {"textAlign":"center","level":4} -->
 <h4 class="has-text-align-center" id="personal-95"><?php echo esc_html__( 'Professional', 'frost' ); ?> - $295</h4>
 <!-- /wp:heading -->
 </div>
 <!-- /wp:group -->
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"},"blockGap":"10px"},"border":{"width":"1px","style":"solid"}},"borderColor":"main"} -->
-<div class="wp-block-group has-border-color has-main-border-color" style="border-style:solid;border-width:1px;padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px">
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"},"blockGap":"10px"},"border":{"width":"1px","style":"solid"}},"borderColor":"foreground"} -->
+<div class="wp-block-group has-border-color has-foreground-border-color" style="border-style:solid;border-width:1px;padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px">
 <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 <p class="has-text-align-center has-small-font-size"><?php echo esc_html__( 'Feature Item', 'frost' ); ?></p>
 <!-- /wp:paragraph -->
@@ -126,15 +126,15 @@
 <!-- /wp:column -->
 <!-- wp:column {"style":{"spacing":{"blockGap":"0px"}}} -->
 <div class="wp-block-column">
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"main","textColor":"background"} -->
-<div class="wp-block-group has-background-color has-main-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"foreground","textColor":"background"} -->
+<div class="wp-block-group has-background-color has-foreground-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
 <!-- wp:heading {"textAlign":"center","level":4} -->
 <h4 class="has-text-align-center" id="personal-95"><?php echo esc_html__( 'Enterprise', 'frost' ); ?> - $495</h4>
 <!-- /wp:heading -->
 </div>
 <!-- /wp:group -->
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"},"blockGap":"10px"},"border":{"width":"1px","style":"solid"}},"borderColor":"main"} -->
-<div class="wp-block-group has-border-color has-main-border-color" style="border-style:solid;border-width:1px;padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px">
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"},"blockGap":"10px"},"border":{"width":"1px","style":"solid"}},"borderColor":"foreground"} -->
+<div class="wp-block-group has-border-color has-foreground-border-color" style="border-style:solid;border-width:1px;padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px">
 <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 <p class="has-text-align-center has-small-font-size"><?php echo esc_html__( 'Feature Item', 'frost' ); ?></p>
 <!-- /wp:paragraph -->
@@ -178,15 +178,15 @@
 <!-- /wp:column -->
 <!-- wp:column {"style":{"spacing":{"blockGap":"0px"}}} -->
 <div class="wp-block-column">
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"main","textColor":"background"} -->
-<div class="wp-block-group has-background-color has-main-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"foreground","textColor":"background"} -->
+<div class="wp-block-group has-background-color has-foreground-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
 <!-- wp:heading {"textAlign":"center","level":4} -->
 <h4 class="has-text-align-center" id="personal-95"><?php echo esc_html__( 'Ultimate', 'frost' ); ?> - $995</h4>
 <!-- /wp:heading -->
 </div>
 <!-- /wp:group -->
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"},"blockGap":"10px"},"border":{"width":"1px","style":"solid"}},"borderColor":"main"} -->
-<div class="wp-block-group has-border-color has-main-border-color" style="border-style:solid;border-width:1px;padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px">
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"},"blockGap":"10px"},"border":{"width":"1px","style":"solid"}},"borderColor":"foreground"} -->
+<div class="wp-block-group has-border-color has-foreground-border-color" style="border-style:solid;border-width:1px;padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px">
 <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 <p class="has-text-align-center has-small-font-size"><?php echo esc_html__( 'Feature Item', 'frost' ); ?></p>
 <!-- /wp:paragraph -->

--- a/patterns/general-pricing-four-columns.php
+++ b/patterns/general-pricing-four-columns.php
@@ -22,8 +22,8 @@
 <div class="wp-block-columns alignwide has-smaller-left-margin">
 <!-- wp:column {"style":{"spacing":{"blockGap":"0px"}}} -->
 <div class="wp-block-column">
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"main","textColor":"base"} -->
-<div class="wp-block-group has-base-color has-main-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"main","textColor":"background"} -->
+<div class="wp-block-group has-background-color has-main-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
 <!-- wp:heading {"textAlign":"center","level":4} -->
 <h4 class="has-text-align-center" id="personal-95"><?php echo esc_html__( 'Personal', 'frost' ); ?> - $95</h4>
 <!-- /wp:heading -->
@@ -74,8 +74,8 @@
 <!-- /wp:column -->
 <!-- wp:column {"style":{"spacing":{"blockGap":"0px"}}} -->
 <div class="wp-block-column">
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"main","textColor":"base"} -->
-<div class="wp-block-group has-base-color has-main-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"main","textColor":"background"} -->
+<div class="wp-block-group has-background-color has-main-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
 <!-- wp:heading {"textAlign":"center","level":4} -->
 <h4 class="has-text-align-center" id="personal-95"><?php echo esc_html__( 'Professional', 'frost' ); ?> - $295</h4>
 <!-- /wp:heading -->
@@ -126,8 +126,8 @@
 <!-- /wp:column -->
 <!-- wp:column {"style":{"spacing":{"blockGap":"0px"}}} -->
 <div class="wp-block-column">
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"main","textColor":"base"} -->
-<div class="wp-block-group has-base-color has-main-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"main","textColor":"background"} -->
+<div class="wp-block-group has-background-color has-main-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
 <!-- wp:heading {"textAlign":"center","level":4} -->
 <h4 class="has-text-align-center" id="personal-95"><?php echo esc_html__( 'Enterprise', 'frost' ); ?> - $495</h4>
 <!-- /wp:heading -->
@@ -178,8 +178,8 @@
 <!-- /wp:column -->
 <!-- wp:column {"style":{"spacing":{"blockGap":"0px"}}} -->
 <div class="wp-block-column">
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"main","textColor":"base"} -->
-<div class="wp-block-group has-base-color has-main-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"main","textColor":"background"} -->
+<div class="wp-block-group has-background-color has-main-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
 <!-- wp:heading {"textAlign":"center","level":4} -->
 <h4 class="has-text-align-center" id="personal-95"><?php echo esc_html__( 'Ultimate', 'frost' ); ?> - $995</h4>
 <!-- /wp:heading -->

--- a/patterns/general-pricing-three-columns-main-background.php
+++ b/patterns/general-pricing-three-columns-main-background.php
@@ -7,8 +7,8 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"main","textColor":"background","layout":{"inherit":true}} -->
-<div class="wp-block-group alignfull has-background-color has-main-background-color has-text-color has-background" style="margin-top:0px">
+<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull has-background-color has-foreground-background-color has-text-color has-background" style="margin-top:0px">
 <!-- wp:spacer -->
 <div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
@@ -22,8 +22,8 @@
 <div class="wp-block-columns alignwide has-smaller-left-margin">
 <!-- wp:column {"style":{"spacing":{"blockGap":"0px"}}} -->
 <div class="wp-block-column">
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"background","textColor":"main"} -->
-<div class="wp-block-group has-main-color has-background-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"background","textColor":"foreground"} -->
+<div class="wp-block-group has-foreground-color has-background-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
 <!-- wp:heading {"textAlign":"center","level":4} -->
 <h4 class="has-text-align-center" id="personal-95"><?php echo esc_html__( 'Personal', 'frost' ); ?> - $95</h4>
 <!-- /wp:heading -->
@@ -63,8 +63,8 @@
 <!-- /wp:separator -->
 <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"40px"}}}} -->
 <div class="wp-block-buttons" style="margin-top:40px">
-<!-- wp:button {"backgroundColor":"background","textColor":"main"} -->
-<div class="wp-block-button"><a class="wp-block-button__link has-main-color has-background-background-color has-text-color has-background"><?php echo esc_html__( 'Sign Up Now', 'frost' ); ?></a></div>
+<!-- wp:button {"backgroundColor":"background","textColor":"foreground"} -->
+<div class="wp-block-button"><a class="wp-block-button__link has-foreground-color has-background-background-color has-text-color has-background"><?php echo esc_html__( 'Sign Up Now', 'frost' ); ?></a></div>
 <!-- /wp:button -->
 </div>
 <!-- /wp:buttons -->
@@ -74,8 +74,8 @@
 <!-- /wp:column -->
 <!-- wp:column {"style":{"spacing":{"blockGap":"0px"}}} -->
 <div class="wp-block-column">
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"background","textColor":"main"} -->
-<div class="wp-block-group has-main-color has-background-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"background","textColor":"foreground"} -->
+<div class="wp-block-group has-foreground-color has-background-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
 <!-- wp:heading {"textAlign":"center","level":4} -->
 <h4 class="has-text-align-center" id="personal-95"><?php echo esc_html__( 'Professional', 'frost' ); ?> - $295</h4>
 <!-- /wp:heading -->
@@ -115,8 +115,8 @@
 <!-- /wp:separator -->
 <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"40px"}}}} -->
 <div class="wp-block-buttons" style="margin-top:40px">
-<!-- wp:button {"backgroundColor":"background","textColor":"main"} -->
-<div class="wp-block-button"><a class="wp-block-button__link has-main-color has-background-background-color has-text-color has-background"><?php echo esc_html__( 'Sign Up Now', 'frost' ); ?></a></div>
+<!-- wp:button {"backgroundColor":"background","textColor":"foreground"} -->
+<div class="wp-block-button"><a class="wp-block-button__link has-foreground-color has-background-background-color has-text-color has-background"><?php echo esc_html__( 'Sign Up Now', 'frost' ); ?></a></div>
 <!-- /wp:button -->
 </div>
 <!-- /wp:buttons -->
@@ -126,8 +126,8 @@
 <!-- /wp:column -->
 <!-- wp:column {"style":{"spacing":{"blockGap":"0px"}}} -->
 <div class="wp-block-column">
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"background","textColor":"main"} -->
-<div class="wp-block-group has-main-color has-background-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"background","textColor":"foreground"} -->
+<div class="wp-block-group has-foreground-color has-background-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
 <!-- wp:heading {"textAlign":"center","level":4} -->
 <h4 class="has-text-align-center" id="personal-95"><?php echo esc_html__( 'Enterprise', 'frost' ); ?> - $495</h4>
 <!-- /wp:heading -->
@@ -167,8 +167,8 @@
 <!-- /wp:separator -->
 <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"40px"}}}} -->
 <div class="wp-block-buttons" style="margin-top:40px">
-<!-- wp:button {"backgroundColor":"background","textColor":"main"} -->
-<div class="wp-block-button"><a class="wp-block-button__link has-main-color has-background-background-color has-text-color has-background"><?php echo esc_html__( 'Sign Up Now', 'frost' ); ?></a></div>
+<!-- wp:button {"backgroundColor":"background","textColor":"foreground"} -->
+<div class="wp-block-button"><a class="wp-block-button__link has-foreground-color has-background-background-color has-text-color has-background"><?php echo esc_html__( 'Sign Up Now', 'frost' ); ?></a></div>
 <!-- /wp:button -->
 </div>
 <!-- /wp:buttons -->

--- a/patterns/general-pricing-three-columns-main-background.php
+++ b/patterns/general-pricing-three-columns-main-background.php
@@ -7,8 +7,8 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"main","textColor":"base","layout":{"inherit":true}} -->
-<div class="wp-block-group alignfull has-base-color has-main-background-color has-text-color has-background" style="margin-top:0px">
+<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"main","textColor":"background","layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull has-background-color has-main-background-color has-text-color has-background" style="margin-top:0px">
 <!-- wp:spacer -->
 <div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
@@ -22,49 +22,49 @@
 <div class="wp-block-columns alignwide has-smaller-left-margin">
 <!-- wp:column {"style":{"spacing":{"blockGap":"0px"}}} -->
 <div class="wp-block-column">
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"base","textColor":"main"} -->
-<div class="wp-block-group has-main-color has-base-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"background","textColor":"main"} -->
+<div class="wp-block-group has-main-color has-background-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
 <!-- wp:heading {"textAlign":"center","level":4} -->
 <h4 class="has-text-align-center" id="personal-95"><?php echo esc_html__( 'Personal', 'frost' ); ?> - $95</h4>
 <!-- /wp:heading -->
 </div>
 <!-- /wp:group -->
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"},"blockGap":"10px"},"border":{"width":"1px","style":"solid"}},"borderColor":"base"} -->
-<div class="wp-block-group has-border-color has-base-border-color" style="border-style:solid;border-width:1px;padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px">
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"},"blockGap":"10px"},"border":{"width":"1px","style":"solid"}},"borderColor":"background"} -->
+<div class="wp-block-group has-border-color has-background-border-color" style="border-style:solid;border-width:1px;padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px">
 <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 <p class="has-text-align-center has-small-font-size"><?php echo esc_html__( 'Feature Item', 'frost' ); ?></p>
 <!-- /wp:paragraph -->
-<!-- wp:separator {"backgroundColor":"base","className":"is-style-wide"} -->
-<hr class="wp-block-separator has-text-color has-base-color has-alpha-channel-opacity has-base-background-color has-background is-style-wide"/>
+<!-- wp:separator {"backgroundColor":"background","className":"is-style-wide"} -->
+<hr class="wp-block-separator has-text-color has-background-color has-alpha-channel-opacity has-background-background-color has-background is-style-wide"/>
 <!-- /wp:separator -->
 <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 <p class="has-text-align-center has-small-font-size"><?php echo esc_html__( 'Feature Item', 'frost' ); ?></p>
 <!-- /wp:paragraph -->
-<!-- wp:separator {"backgroundColor":"base","className":"is-style-wide"} -->
-<hr class="wp-block-separator has-text-color has-base-color has-alpha-channel-opacity has-base-background-color has-background is-style-wide"/>
+<!-- wp:separator {"backgroundColor":"background","className":"is-style-wide"} -->
+<hr class="wp-block-separator has-text-color has-background-color has-alpha-channel-opacity has-background-background-color has-background is-style-wide"/>
 <!-- /wp:separator -->
 <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 <p class="has-text-align-center has-small-font-size"><?php echo esc_html__( 'Feature Item', 'frost' ); ?></p>
 <!-- /wp:paragraph -->
-<!-- wp:separator {"backgroundColor":"base","className":"is-style-wide"} -->
-<hr class="wp-block-separator has-text-color has-base-color has-alpha-channel-opacity has-base-background-color has-background is-style-wide"/>
+<!-- wp:separator {"backgroundColor":"background","className":"is-style-wide"} -->
+<hr class="wp-block-separator has-text-color has-background-color has-alpha-channel-opacity has-background-background-color has-background is-style-wide"/>
 <!-- /wp:separator -->
 <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 <p class="has-text-align-center has-small-font-size"><?php echo esc_html__( 'Feature Item', 'frost' ); ?></p>
 <!-- /wp:paragraph -->
-<!-- wp:separator {"backgroundColor":"base","className":"is-style-wide"} -->
-<hr class="wp-block-separator has-text-color has-base-color has-alpha-channel-opacity has-base-background-color has-background is-style-wide"/>
+<!-- wp:separator {"backgroundColor":"background","className":"is-style-wide"} -->
+<hr class="wp-block-separator has-text-color has-background-color has-alpha-channel-opacity has-background-background-color has-background is-style-wide"/>
 <!-- /wp:separator -->
 <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 <p class="has-text-align-center has-small-font-size"><?php echo esc_html__( 'Feature Item', 'frost' ); ?></p>
 <!-- /wp:paragraph -->
-<!-- wp:separator {"backgroundColor":"base","className":"is-style-wide"} -->
-<hr class="wp-block-separator has-text-color has-base-color has-alpha-channel-opacity has-base-background-color has-background is-style-wide"/>
+<!-- wp:separator {"backgroundColor":"background","className":"is-style-wide"} -->
+<hr class="wp-block-separator has-text-color has-background-color has-alpha-channel-opacity has-background-background-color has-background is-style-wide"/>
 <!-- /wp:separator -->
 <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"40px"}}}} -->
 <div class="wp-block-buttons" style="margin-top:40px">
-<!-- wp:button {"backgroundColor":"base","textColor":"main"} -->
-<div class="wp-block-button"><a class="wp-block-button__link has-main-color has-base-background-color has-text-color has-background"><?php echo esc_html__( 'Sign Up Now', 'frost' ); ?></a></div>
+<!-- wp:button {"backgroundColor":"background","textColor":"main"} -->
+<div class="wp-block-button"><a class="wp-block-button__link has-main-color has-background-background-color has-text-color has-background"><?php echo esc_html__( 'Sign Up Now', 'frost' ); ?></a></div>
 <!-- /wp:button -->
 </div>
 <!-- /wp:buttons -->
@@ -74,49 +74,49 @@
 <!-- /wp:column -->
 <!-- wp:column {"style":{"spacing":{"blockGap":"0px"}}} -->
 <div class="wp-block-column">
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"base","textColor":"main"} -->
-<div class="wp-block-group has-main-color has-base-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"background","textColor":"main"} -->
+<div class="wp-block-group has-main-color has-background-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
 <!-- wp:heading {"textAlign":"center","level":4} -->
 <h4 class="has-text-align-center" id="personal-95"><?php echo esc_html__( 'Professional', 'frost' ); ?> - $295</h4>
 <!-- /wp:heading -->
 </div>
 <!-- /wp:group -->
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"},"blockGap":"10px"},"border":{"width":"1px","style":"solid"}},"borderColor":"base"} -->
-<div class="wp-block-group has-border-color has-base-border-color" style="border-style:solid;border-width:1px;padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px">
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"},"blockGap":"10px"},"border":{"width":"1px","style":"solid"}},"borderColor":"background"} -->
+<div class="wp-block-group has-border-color has-background-border-color" style="border-style:solid;border-width:1px;padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px">
 <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 <p class="has-text-align-center has-small-font-size"><?php echo esc_html__( 'Feature Item', 'frost' ); ?></p>
 <!-- /wp:paragraph -->
-<!-- wp:separator {"backgroundColor":"base","className":"is-style-wide"} -->
-<hr class="wp-block-separator has-text-color has-base-color has-alpha-channel-opacity has-base-background-color has-background is-style-wide"/>
+<!-- wp:separator {"backgroundColor":"background","className":"is-style-wide"} -->
+<hr class="wp-block-separator has-text-color has-background-color has-alpha-channel-opacity has-background-background-color has-background is-style-wide"/>
 <!-- /wp:separator -->
 <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 <p class="has-text-align-center has-small-font-size"><?php echo esc_html__( 'Feature Item', 'frost' ); ?></p>
 <!-- /wp:paragraph -->
-<!-- wp:separator {"backgroundColor":"base","className":"is-style-wide"} -->
-<hr class="wp-block-separator has-text-color has-base-color has-alpha-channel-opacity has-base-background-color has-background is-style-wide"/>
+<!-- wp:separator {"backgroundColor":"background","className":"is-style-wide"} -->
+<hr class="wp-block-separator has-text-color has-background-color has-alpha-channel-opacity has-background-background-color has-background is-style-wide"/>
 <!-- /wp:separator -->
 <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 <p class="has-text-align-center has-small-font-size"><?php echo esc_html__( 'Feature Item', 'frost' ); ?></p>
 <!-- /wp:paragraph -->
-<!-- wp:separator {"backgroundColor":"base","className":"is-style-wide"} -->
-<hr class="wp-block-separator has-text-color has-base-color has-alpha-channel-opacity has-base-background-color has-background is-style-wide"/>
+<!-- wp:separator {"backgroundColor":"background","className":"is-style-wide"} -->
+<hr class="wp-block-separator has-text-color has-background-color has-alpha-channel-opacity has-background-background-color has-background is-style-wide"/>
 <!-- /wp:separator -->
 <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 <p class="has-text-align-center has-small-font-size"><?php echo esc_html__( 'Feature Item', 'frost' ); ?></p>
 <!-- /wp:paragraph -->
-<!-- wp:separator {"backgroundColor":"base","className":"is-style-wide"} -->
-<hr class="wp-block-separator has-text-color has-base-color has-alpha-channel-opacity has-base-background-color has-background is-style-wide"/>
+<!-- wp:separator {"backgroundColor":"background","className":"is-style-wide"} -->
+<hr class="wp-block-separator has-text-color has-background-color has-alpha-channel-opacity has-background-background-color has-background is-style-wide"/>
 <!-- /wp:separator -->
 <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 <p class="has-text-align-center has-small-font-size"><?php echo esc_html__( 'Feature Item', 'frost' ); ?></p>
 <!-- /wp:paragraph -->
-<!-- wp:separator {"backgroundColor":"base","className":"is-style-wide"} -->
-<hr class="wp-block-separator has-text-color has-base-color has-alpha-channel-opacity has-base-background-color has-background is-style-wide"/>
+<!-- wp:separator {"backgroundColor":"background","className":"is-style-wide"} -->
+<hr class="wp-block-separator has-text-color has-background-color has-alpha-channel-opacity has-background-background-color has-background is-style-wide"/>
 <!-- /wp:separator -->
 <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"40px"}}}} -->
 <div class="wp-block-buttons" style="margin-top:40px">
-<!-- wp:button {"backgroundColor":"base","textColor":"main"} -->
-<div class="wp-block-button"><a class="wp-block-button__link has-main-color has-base-background-color has-text-color has-background"><?php echo esc_html__( 'Sign Up Now', 'frost' ); ?></a></div>
+<!-- wp:button {"backgroundColor":"background","textColor":"main"} -->
+<div class="wp-block-button"><a class="wp-block-button__link has-main-color has-background-background-color has-text-color has-background"><?php echo esc_html__( 'Sign Up Now', 'frost' ); ?></a></div>
 <!-- /wp:button -->
 </div>
 <!-- /wp:buttons -->
@@ -126,49 +126,49 @@
 <!-- /wp:column -->
 <!-- wp:column {"style":{"spacing":{"blockGap":"0px"}}} -->
 <div class="wp-block-column">
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"base","textColor":"main"} -->
-<div class="wp-block-group has-main-color has-base-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"background","textColor":"main"} -->
+<div class="wp-block-group has-main-color has-background-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
 <!-- wp:heading {"textAlign":"center","level":4} -->
 <h4 class="has-text-align-center" id="personal-95"><?php echo esc_html__( 'Enterprise', 'frost' ); ?> - $495</h4>
 <!-- /wp:heading -->
 </div>
 <!-- /wp:group -->
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"},"blockGap":"10px"},"border":{"width":"1px","style":"solid"}},"borderColor":"base"} -->
-<div class="wp-block-group has-border-color has-base-border-color" style="border-style:solid;border-width:1px;padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px">
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"},"blockGap":"10px"},"border":{"width":"1px","style":"solid"}},"borderColor":"background"} -->
+<div class="wp-block-group has-border-color has-background-border-color" style="border-style:solid;border-width:1px;padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px">
 <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 <p class="has-text-align-center has-small-font-size"><?php echo esc_html__( 'Feature Item', 'frost' ); ?></p>
 <!-- /wp:paragraph -->
-<!-- wp:separator {"backgroundColor":"base","className":"is-style-wide"} -->
-<hr class="wp-block-separator has-text-color has-base-color has-alpha-channel-opacity has-base-background-color has-background is-style-wide"/>
+<!-- wp:separator {"backgroundColor":"background","className":"is-style-wide"} -->
+<hr class="wp-block-separator has-text-color has-background-color has-alpha-channel-opacity has-background-background-color has-background is-style-wide"/>
 <!-- /wp:separator -->
 <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 <p class="has-text-align-center has-small-font-size"><?php echo esc_html__( 'Feature Item', 'frost' ); ?></p>
 <!-- /wp:paragraph -->
-<!-- wp:separator {"backgroundColor":"base","className":"is-style-wide"} -->
-<hr class="wp-block-separator has-text-color has-base-color has-alpha-channel-opacity has-base-background-color has-background is-style-wide"/>
+<!-- wp:separator {"backgroundColor":"background","className":"is-style-wide"} -->
+<hr class="wp-block-separator has-text-color has-background-color has-alpha-channel-opacity has-background-background-color has-background is-style-wide"/>
 <!-- /wp:separator -->
 <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 <p class="has-text-align-center has-small-font-size"><?php echo esc_html__( 'Feature Item', 'frost' ); ?></p>
 <!-- /wp:paragraph -->
-<!-- wp:separator {"backgroundColor":"base","className":"is-style-wide"} -->
-<hr class="wp-block-separator has-text-color has-base-color has-alpha-channel-opacity has-base-background-color has-background is-style-wide"/>
+<!-- wp:separator {"backgroundColor":"background","className":"is-style-wide"} -->
+<hr class="wp-block-separator has-text-color has-background-color has-alpha-channel-opacity has-background-background-color has-background is-style-wide"/>
 <!-- /wp:separator -->
 <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 <p class="has-text-align-center has-small-font-size"><?php echo esc_html__( 'Feature Item', 'frost' ); ?></p>
 <!-- /wp:paragraph -->
-<!-- wp:separator {"backgroundColor":"base","className":"is-style-wide"} -->
-<hr class="wp-block-separator has-text-color has-base-color has-alpha-channel-opacity has-base-background-color has-background is-style-wide"/>
+<!-- wp:separator {"backgroundColor":"background","className":"is-style-wide"} -->
+<hr class="wp-block-separator has-text-color has-background-color has-alpha-channel-opacity has-background-background-color has-background is-style-wide"/>
 <!-- /wp:separator -->
 <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 <p class="has-text-align-center has-small-font-size"><?php echo esc_html__( 'Feature Item', 'frost' ); ?></p>
 <!-- /wp:paragraph -->
-<!-- wp:separator {"backgroundColor":"base","className":"is-style-wide"} -->
-<hr class="wp-block-separator has-text-color has-base-color has-alpha-channel-opacity has-base-background-color has-background is-style-wide"/>
+<!-- wp:separator {"backgroundColor":"background","className":"is-style-wide"} -->
+<hr class="wp-block-separator has-text-color has-background-color has-alpha-channel-opacity has-background-background-color has-background is-style-wide"/>
 <!-- /wp:separator -->
 <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"40px"}}}} -->
 <div class="wp-block-buttons" style="margin-top:40px">
-<!-- wp:button {"backgroundColor":"base","textColor":"main"} -->
-<div class="wp-block-button"><a class="wp-block-button__link has-main-color has-base-background-color has-text-color has-background"><?php echo esc_html__( 'Sign Up Now', 'frost' ); ?></a></div>
+<!-- wp:button {"backgroundColor":"background","textColor":"main"} -->
+<div class="wp-block-button"><a class="wp-block-button__link has-main-color has-background-background-color has-text-color has-background"><?php echo esc_html__( 'Sign Up Now', 'frost' ); ?></a></div>
 <!-- /wp:button -->
 </div>
 <!-- /wp:buttons -->

--- a/patterns/general-pricing-three-columns.php
+++ b/patterns/general-pricing-three-columns.php
@@ -22,15 +22,15 @@
 <div class="wp-block-columns alignwide has-smaller-left-margin">
 <!-- wp:column {"style":{"spacing":{"blockGap":"0px"}}} -->
 <div class="wp-block-column">
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"main","textColor":"background"} -->
-<div class="wp-block-group has-background-color has-main-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"foreground","textColor":"background"} -->
+<div class="wp-block-group has-background-color has-foreground-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
 <!-- wp:heading {"textAlign":"center","level":4} -->
 <h4 class="has-text-align-center" id="personal-95"><?php echo esc_html__( 'Personal', 'frost' ); ?> - $95</h4>
 <!-- /wp:heading -->
 </div>
 <!-- /wp:group -->
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"},"blockGap":"10px"},"border":{"width":"1px","style":"solid"}},"borderColor":"main"} -->
-<div class="wp-block-group has-border-color has-main-border-color" style="border-style:solid;border-width:1px;padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px">
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"},"blockGap":"10px"},"border":{"width":"1px","style":"solid"}},"borderColor":"foreground"} -->
+<div class="wp-block-group has-border-color has-foreground-border-color" style="border-style:solid;border-width:1px;padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px">
 <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 <p class="has-text-align-center has-small-font-size"><?php echo esc_html__( 'Feature Item', 'frost' ); ?></p>
 <!-- /wp:paragraph -->
@@ -74,15 +74,15 @@
 <!-- /wp:column -->
 <!-- wp:column {"style":{"spacing":{"blockGap":"0px"}}} -->
 <div class="wp-block-column">
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"main","textColor":"background"} -->
-<div class="wp-block-group has-background-color has-main-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"foreground","textColor":"background"} -->
+<div class="wp-block-group has-background-color has-foreground-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
 <!-- wp:heading {"textAlign":"center","level":4} -->
 <h4 class="has-text-align-center" id="personal-95"><?php echo esc_html__( 'Professional', 'frost' ); ?> - $295</h4>
 <!-- /wp:heading -->
 </div>
 <!-- /wp:group -->
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"},"blockGap":"10px"},"border":{"width":"1px","style":"solid"}},"borderColor":"main"} -->
-<div class="wp-block-group has-border-color has-main-border-color" style="border-style:solid;border-width:1px;padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px">
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"},"blockGap":"10px"},"border":{"width":"1px","style":"solid"}},"borderColor":"foreground"} -->
+<div class="wp-block-group has-border-color has-foreground-border-color" style="border-style:solid;border-width:1px;padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px">
 <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 <p class="has-text-align-center has-small-font-size"><?php echo esc_html__( 'Feature Item', 'frost' ); ?></p>
 <!-- /wp:paragraph -->
@@ -126,15 +126,15 @@
 <!-- /wp:column -->
 <!-- wp:column {"style":{"spacing":{"blockGap":"0px"}}} -->
 <div class="wp-block-column">
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"main","textColor":"background"} -->
-<div class="wp-block-group has-background-color has-main-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"foreground","textColor":"background"} -->
+<div class="wp-block-group has-background-color has-foreground-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
 <!-- wp:heading {"textAlign":"center","level":4} -->
 <h4 class="has-text-align-center" id="personal-95"><?php echo esc_html__( 'Enterprise', 'frost' ); ?> - $495</h4>
 <!-- /wp:heading -->
 </div>
 <!-- /wp:group -->
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"},"blockGap":"10px"},"border":{"width":"1px","style":"solid"}},"borderColor":"main"} -->
-<div class="wp-block-group has-border-color has-main-border-color" style="border-style:solid;border-width:1px;padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px">
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"},"blockGap":"10px"},"border":{"width":"1px","style":"solid"}},"borderColor":"foreground"} -->
+<div class="wp-block-group has-border-color has-foreground-border-color" style="border-style:solid;border-width:1px;padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px">
 <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 <p class="has-text-align-center has-small-font-size"><?php echo esc_html__( 'Feature Item', 'frost' ); ?></p>
 <!-- /wp:paragraph -->

--- a/patterns/general-pricing-three-columns.php
+++ b/patterns/general-pricing-three-columns.php
@@ -22,8 +22,8 @@
 <div class="wp-block-columns alignwide has-smaller-left-margin">
 <!-- wp:column {"style":{"spacing":{"blockGap":"0px"}}} -->
 <div class="wp-block-column">
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"main","textColor":"base"} -->
-<div class="wp-block-group has-base-color has-main-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"main","textColor":"background"} -->
+<div class="wp-block-group has-background-color has-main-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
 <!-- wp:heading {"textAlign":"center","level":4} -->
 <h4 class="has-text-align-center" id="personal-95"><?php echo esc_html__( 'Personal', 'frost' ); ?> - $95</h4>
 <!-- /wp:heading -->
@@ -74,8 +74,8 @@
 <!-- /wp:column -->
 <!-- wp:column {"style":{"spacing":{"blockGap":"0px"}}} -->
 <div class="wp-block-column">
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"main","textColor":"base"} -->
-<div class="wp-block-group has-base-color has-main-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"main","textColor":"background"} -->
+<div class="wp-block-group has-background-color has-main-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
 <!-- wp:heading {"textAlign":"center","level":4} -->
 <h4 class="has-text-align-center" id="personal-95"><?php echo esc_html__( 'Professional', 'frost' ); ?> - $295</h4>
 <!-- /wp:heading -->
@@ -126,8 +126,8 @@
 <!-- /wp:column -->
 <!-- wp:column {"style":{"spacing":{"blockGap":"0px"}}} -->
 <div class="wp-block-column">
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"main","textColor":"base"} -->
-<div class="wp-block-group has-base-color has-main-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"main","textColor":"background"} -->
+<div class="wp-block-group has-background-color has-main-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
 <!-- wp:heading {"textAlign":"center","level":4} -->
 <h4 class="has-text-align-center" id="personal-95"><?php echo esc_html__( 'Enterprise', 'frost' ); ?> - $495</h4>
 <!-- /wp:heading -->

--- a/patterns/general-pricing-two-columns-main-background.php
+++ b/patterns/general-pricing-two-columns-main-background.php
@@ -8,8 +8,8 @@
 
 ?>
 
-<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"main","textColor":"background","layout":{"inherit":false,"contentSize":"800px"}} -->
-<div class="wp-block-group alignfull has-background-color has-main-background-color has-text-color has-background" style="margin-top:0px">
+<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":false,"contentSize":"800px"}} -->
+<div class="wp-block-group alignfull has-background-color has-foreground-background-color has-text-color has-background" style="margin-top:0px">
 <!-- wp:spacer -->
 <div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
@@ -23,8 +23,8 @@
 <div class="wp-block-columns alignwide has-smaller-left-margin">
 <!-- wp:column {"style":{"spacing":{"blockGap":"0px"}}} -->
 <div class="wp-block-column">
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"background","textColor":"main"} -->
-<div class="wp-block-group has-main-color has-background-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"background","textColor":"foreground"} -->
+<div class="wp-block-group has-foreground-color has-background-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
 <!-- wp:heading {"textAlign":"center","level":4} -->
 <h4 class="has-text-align-center" id="personal-95"><?php echo esc_html__( 'Personal', 'frost' ); ?> - $95</h4>
 <!-- /wp:heading -->
@@ -64,8 +64,8 @@
 <!-- /wp:separator -->
 <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"40px"}}}} -->
 <div class="wp-block-buttons" style="margin-top:40px">
-<!-- wp:button {"backgroundColor":"background","textColor":"main"} -->
-<div class="wp-block-button"><a class="wp-block-button__link has-main-color has-background-background-color has-text-color has-background"><?php echo esc_html__( 'Sign Up Now', 'frost' ); ?></a></div>
+<!-- wp:button {"backgroundColor":"background","textColor":"foreground"} -->
+<div class="wp-block-button"><a class="wp-block-button__link has-foreground-color has-background-background-color has-text-color has-background"><?php echo esc_html__( 'Sign Up Now', 'frost' ); ?></a></div>
 <!-- /wp:button -->
 </div>
 <!-- /wp:buttons -->
@@ -75,8 +75,8 @@
 <!-- /wp:column -->
 <!-- wp:column {"style":{"spacing":{"blockGap":"0px"}}} -->
 <div class="wp-block-column">
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"background","textColor":"main"} -->
-<div class="wp-block-group has-main-color has-background-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"background","textColor":"foreground"} -->
+<div class="wp-block-group has-foreground-color has-background-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
 <!-- wp:heading {"textAlign":"center","level":4} -->
 <h4 class="has-text-align-center" id="personal-95"><?php echo esc_html__( 'Professional', 'frost' ); ?> - $295</h4>
 <!-- /wp:heading -->
@@ -116,8 +116,8 @@
 <!-- /wp:separator -->
 <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"40px"}}}} -->
 <div class="wp-block-buttons" style="margin-top:40px">
-<!-- wp:button {"backgroundColor":"background","textColor":"main"} -->
-<div class="wp-block-button"><a class="wp-block-button__link has-main-color has-background-background-color has-text-color has-background"><?php echo esc_html__( 'Sign Up Now', 'frost' ); ?></a></div>
+<!-- wp:button {"backgroundColor":"background","textColor":"foreground"} -->
+<div class="wp-block-button"><a class="wp-block-button__link has-foreground-color has-background-background-color has-text-color has-background"><?php echo esc_html__( 'Sign Up Now', 'frost' ); ?></a></div>
 <!-- /wp:button -->
 </div>
 <!-- /wp:buttons -->

--- a/patterns/general-pricing-two-columns-main-background.php
+++ b/patterns/general-pricing-two-columns-main-background.php
@@ -8,8 +8,8 @@
 
 ?>
 
-<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"main","textColor":"base","layout":{"inherit":false,"contentSize":"800px"}} -->
-<div class="wp-block-group alignfull has-base-color has-main-background-color has-text-color has-background" style="margin-top:0px">
+<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"main","textColor":"background","layout":{"inherit":false,"contentSize":"800px"}} -->
+<div class="wp-block-group alignfull has-background-color has-main-background-color has-text-color has-background" style="margin-top:0px">
 <!-- wp:spacer -->
 <div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
@@ -23,49 +23,49 @@
 <div class="wp-block-columns alignwide has-smaller-left-margin">
 <!-- wp:column {"style":{"spacing":{"blockGap":"0px"}}} -->
 <div class="wp-block-column">
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"base","textColor":"main"} -->
-<div class="wp-block-group has-main-color has-base-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"background","textColor":"main"} -->
+<div class="wp-block-group has-main-color has-background-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
 <!-- wp:heading {"textAlign":"center","level":4} -->
 <h4 class="has-text-align-center" id="personal-95"><?php echo esc_html__( 'Personal', 'frost' ); ?> - $95</h4>
 <!-- /wp:heading -->
 </div>
 <!-- /wp:group -->
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"},"blockGap":"10px"},"border":{"width":"1px","style":"solid"}},"borderColor":"base"} -->
-<div class="wp-block-group has-border-color has-base-border-color" style="border-style:solid;border-width:1px;padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px">
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"},"blockGap":"10px"},"border":{"width":"1px","style":"solid"}},"borderColor":"background"} -->
+<div class="wp-block-group has-border-color has-background-border-color" style="border-style:solid;border-width:1px;padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px">
 <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 <p class="has-text-align-center has-small-font-size"><?php echo esc_html__( 'Feature Item', 'frost' ); ?></p>
 <!-- /wp:paragraph -->
-<!-- wp:separator {"backgroundColor":"base","className":"is-style-wide"} -->
-<hr class="wp-block-separator has-text-color has-base-color has-alpha-channel-opacity has-base-background-color has-background is-style-wide"/>
+<!-- wp:separator {"backgroundColor":"background","className":"is-style-wide"} -->
+<hr class="wp-block-separator has-text-color has-background-color has-alpha-channel-opacity has-background-background-color has-background is-style-wide"/>
 <!-- /wp:separator -->
 <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 <p class="has-text-align-center has-small-font-size"><?php echo esc_html__( 'Feature Item', 'frost' ); ?></p>
 <!-- /wp:paragraph -->
-<!-- wp:separator {"backgroundColor":"base","className":"is-style-wide"} -->
-<hr class="wp-block-separator has-text-color has-base-color has-alpha-channel-opacity has-base-background-color has-background is-style-wide"/>
+<!-- wp:separator {"backgroundColor":"background","className":"is-style-wide"} -->
+<hr class="wp-block-separator has-text-color has-background-color has-alpha-channel-opacity has-background-background-color has-background is-style-wide"/>
 <!-- /wp:separator -->
 <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 <p class="has-text-align-center has-small-font-size"><?php echo esc_html__( 'Feature Item', 'frost' ); ?></p>
 <!-- /wp:paragraph -->
-<!-- wp:separator {"backgroundColor":"base","className":"is-style-wide"} -->
-<hr class="wp-block-separator has-text-color has-base-color has-alpha-channel-opacity has-base-background-color has-background is-style-wide"/>
+<!-- wp:separator {"backgroundColor":"background","className":"is-style-wide"} -->
+<hr class="wp-block-separator has-text-color has-background-color has-alpha-channel-opacity has-background-background-color has-background is-style-wide"/>
 <!-- /wp:separator -->
 <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 <p class="has-text-align-center has-small-font-size"><?php echo esc_html__( 'Feature Item', 'frost' ); ?></p>
 <!-- /wp:paragraph -->
-<!-- wp:separator {"backgroundColor":"base","className":"is-style-wide"} -->
-<hr class="wp-block-separator has-text-color has-base-color has-alpha-channel-opacity has-base-background-color has-background is-style-wide"/>
+<!-- wp:separator {"backgroundColor":"background","className":"is-style-wide"} -->
+<hr class="wp-block-separator has-text-color has-background-color has-alpha-channel-opacity has-background-background-color has-background is-style-wide"/>
 <!-- /wp:separator -->
 <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 <p class="has-text-align-center has-small-font-size"><?php echo esc_html__( 'Feature Item', 'frost' ); ?></p>
 <!-- /wp:paragraph -->
-<!-- wp:separator {"backgroundColor":"base","className":"is-style-wide"} -->
-<hr class="wp-block-separator has-text-color has-base-color has-alpha-channel-opacity has-base-background-color has-background is-style-wide"/>
+<!-- wp:separator {"backgroundColor":"background","className":"is-style-wide"} -->
+<hr class="wp-block-separator has-text-color has-background-color has-alpha-channel-opacity has-background-background-color has-background is-style-wide"/>
 <!-- /wp:separator -->
 <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"40px"}}}} -->
 <div class="wp-block-buttons" style="margin-top:40px">
-<!-- wp:button {"backgroundColor":"base","textColor":"main"} -->
-<div class="wp-block-button"><a class="wp-block-button__link has-main-color has-base-background-color has-text-color has-background"><?php echo esc_html__( 'Sign Up Now', 'frost' ); ?></a></div>
+<!-- wp:button {"backgroundColor":"background","textColor":"main"} -->
+<div class="wp-block-button"><a class="wp-block-button__link has-main-color has-background-background-color has-text-color has-background"><?php echo esc_html__( 'Sign Up Now', 'frost' ); ?></a></div>
 <!-- /wp:button -->
 </div>
 <!-- /wp:buttons -->
@@ -75,49 +75,49 @@
 <!-- /wp:column -->
 <!-- wp:column {"style":{"spacing":{"blockGap":"0px"}}} -->
 <div class="wp-block-column">
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"base","textColor":"main"} -->
-<div class="wp-block-group has-main-color has-base-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"background","textColor":"main"} -->
+<div class="wp-block-group has-main-color has-background-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
 <!-- wp:heading {"textAlign":"center","level":4} -->
 <h4 class="has-text-align-center" id="personal-95"><?php echo esc_html__( 'Professional', 'frost' ); ?> - $295</h4>
 <!-- /wp:heading -->
 </div>
 <!-- /wp:group -->
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"},"blockGap":"10px"},"border":{"width":"1px","style":"solid"}},"borderColor":"base"} -->
-<div class="wp-block-group has-border-color has-base-border-color" style="border-style:solid;border-width:1px;padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px">
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"},"blockGap":"10px"},"border":{"width":"1px","style":"solid"}},"borderColor":"background"} -->
+<div class="wp-block-group has-border-color has-background-border-color" style="border-style:solid;border-width:1px;padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px">
 <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 <p class="has-text-align-center has-small-font-size"><?php echo esc_html__( 'Feature Item', 'frost' ); ?></p>
 <!-- /wp:paragraph -->
-<!-- wp:separator {"backgroundColor":"base","className":"is-style-wide"} -->
-<hr class="wp-block-separator has-text-color has-base-color has-alpha-channel-opacity has-base-background-color has-background is-style-wide"/>
+<!-- wp:separator {"backgroundColor":"background","className":"is-style-wide"} -->
+<hr class="wp-block-separator has-text-color has-background-color has-alpha-channel-opacity has-background-background-color has-background is-style-wide"/>
 <!-- /wp:separator -->
 <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 <p class="has-text-align-center has-small-font-size"><?php echo esc_html__( 'Feature Item', 'frost' ); ?></p>
 <!-- /wp:paragraph -->
-<!-- wp:separator {"backgroundColor":"base","className":"is-style-wide"} -->
-<hr class="wp-block-separator has-text-color has-base-color has-alpha-channel-opacity has-base-background-color has-background is-style-wide"/>
+<!-- wp:separator {"backgroundColor":"background","className":"is-style-wide"} -->
+<hr class="wp-block-separator has-text-color has-background-color has-alpha-channel-opacity has-background-background-color has-background is-style-wide"/>
 <!-- /wp:separator -->
 <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 <p class="has-text-align-center has-small-font-size"><?php echo esc_html__( 'Feature Item', 'frost' ); ?></p>
 <!-- /wp:paragraph -->
-<!-- wp:separator {"backgroundColor":"base","className":"is-style-wide"} -->
-<hr class="wp-block-separator has-text-color has-base-color has-alpha-channel-opacity has-base-background-color has-background is-style-wide"/>
+<!-- wp:separator {"backgroundColor":"background","className":"is-style-wide"} -->
+<hr class="wp-block-separator has-text-color has-background-color has-alpha-channel-opacity has-background-background-color has-background is-style-wide"/>
 <!-- /wp:separator -->
 <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 <p class="has-text-align-center has-small-font-size"><?php echo esc_html__( 'Feature Item', 'frost' ); ?></p>
 <!-- /wp:paragraph -->
-<!-- wp:separator {"backgroundColor":"base","className":"is-style-wide"} -->
-<hr class="wp-block-separator has-text-color has-base-color has-alpha-channel-opacity has-base-background-color has-background is-style-wide"/>
+<!-- wp:separator {"backgroundColor":"background","className":"is-style-wide"} -->
+<hr class="wp-block-separator has-text-color has-background-color has-alpha-channel-opacity has-background-background-color has-background is-style-wide"/>
 <!-- /wp:separator -->
 <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 <p class="has-text-align-center has-small-font-size"><?php echo esc_html__( 'Feature Item', 'frost' ); ?></p>
 <!-- /wp:paragraph -->
-<!-- wp:separator {"backgroundColor":"base","className":"is-style-wide"} -->
-<hr class="wp-block-separator has-text-color has-base-color has-alpha-channel-opacity has-base-background-color has-background is-style-wide"/>
+<!-- wp:separator {"backgroundColor":"background","className":"is-style-wide"} -->
+<hr class="wp-block-separator has-text-color has-background-color has-alpha-channel-opacity has-background-background-color has-background is-style-wide"/>
 <!-- /wp:separator -->
 <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center","orientation":"horizontal"},"style":{"spacing":{"margin":{"top":"40px"}}}} -->
 <div class="wp-block-buttons" style="margin-top:40px">
-<!-- wp:button {"backgroundColor":"base","textColor":"main"} -->
-<div class="wp-block-button"><a class="wp-block-button__link has-main-color has-base-background-color has-text-color has-background"><?php echo esc_html__( 'Sign Up Now', 'frost' ); ?></a></div>
+<!-- wp:button {"backgroundColor":"background","textColor":"main"} -->
+<div class="wp-block-button"><a class="wp-block-button__link has-main-color has-background-background-color has-text-color has-background"><?php echo esc_html__( 'Sign Up Now', 'frost' ); ?></a></div>
 <!-- /wp:button -->
 </div>
 <!-- /wp:buttons -->

--- a/patterns/general-pricing-two-columns.php
+++ b/patterns/general-pricing-two-columns.php
@@ -22,15 +22,15 @@
 <div class="wp-block-columns alignwide has-smaller-left-margin">
 <!-- wp:column {"style":{"spacing":{"blockGap":"0px"}}} -->
 <div class="wp-block-column">
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"main","textColor":"background"} -->
-<div class="wp-block-group has-background-color has-main-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"foreground","textColor":"background"} -->
+<div class="wp-block-group has-background-color has-foreground-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
 <!-- wp:heading {"textAlign":"center","level":4} -->
 <h4 class="has-text-align-center" id="personal-95"><?php echo esc_html__( 'Personal', 'frost' ); ?> - $95</h4>
 <!-- /wp:heading -->
 </div>
 <!-- /wp:group -->
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"},"blockGap":"10px"},"border":{"width":"1px","style":"solid"}},"borderColor":"main"} -->
-<div class="wp-block-group has-border-color has-main-border-color" style="border-style:solid;border-width:1px;padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px">
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"},"blockGap":"10px"},"border":{"width":"1px","style":"solid"}},"borderColor":"foreground"} -->
+<div class="wp-block-group has-border-color has-foreground-border-color" style="border-style:solid;border-width:1px;padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px">
 <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 <p class="has-text-align-center has-small-font-size"><?php echo esc_html__( 'Feature Item', 'frost' ); ?></p>
 <!-- /wp:paragraph -->
@@ -74,15 +74,15 @@
 <!-- /wp:column -->
 <!-- wp:column {"style":{"spacing":{"blockGap":"0px"}}} -->
 <div class="wp-block-column">
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"main","textColor":"background"} -->
-<div class="wp-block-group has-background-color has-main-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"foreground","textColor":"background"} -->
+<div class="wp-block-group has-background-color has-foreground-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
 <!-- wp:heading {"textAlign":"center","level":4} -->
 <h4 class="has-text-align-center" id="personal-95"><?php echo esc_html__( 'Professional', 'frost' ); ?> - $295</h4>
 <!-- /wp:heading -->
 </div>
 <!-- /wp:group -->
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"},"blockGap":"10px"},"border":{"width":"1px","style":"solid"}},"borderColor":"main"} -->
-<div class="wp-block-group has-border-color has-main-border-color" style="border-style:solid;border-width:1px;padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px">
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"},"blockGap":"10px"},"border":{"width":"1px","style":"solid"}},"borderColor":"foreground"} -->
+<div class="wp-block-group has-border-color has-foreground-border-color" style="border-style:solid;border-width:1px;padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px">
 <!-- wp:paragraph {"align":"center","fontSize":"small"} -->
 <p class="has-text-align-center has-small-font-size"><?php echo esc_html__( 'Feature Item', 'frost' ); ?></p>
 <!-- /wp:paragraph -->

--- a/patterns/general-pricing-two-columns.php
+++ b/patterns/general-pricing-two-columns.php
@@ -22,8 +22,8 @@
 <div class="wp-block-columns alignwide has-smaller-left-margin">
 <!-- wp:column {"style":{"spacing":{"blockGap":"0px"}}} -->
 <div class="wp-block-column">
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"main","textColor":"base"} -->
-<div class="wp-block-group has-base-color has-main-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"main","textColor":"background"} -->
+<div class="wp-block-group has-background-color has-main-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
 <!-- wp:heading {"textAlign":"center","level":4} -->
 <h4 class="has-text-align-center" id="personal-95"><?php echo esc_html__( 'Personal', 'frost' ); ?> - $95</h4>
 <!-- /wp:heading -->
@@ -74,8 +74,8 @@
 <!-- /wp:column -->
 <!-- wp:column {"style":{"spacing":{"blockGap":"0px"}}} -->
 <div class="wp-block-column">
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"main","textColor":"base"} -->
-<div class="wp-block-group has-base-color has-main-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"20px","right":"30px","bottom":"20px","left":"30px"}}},"backgroundColor":"main","textColor":"background"} -->
+<div class="wp-block-group has-background-color has-main-background-color has-text-color has-background" style="padding-top:20px;padding-right:30px;padding-bottom:20px;padding-left:30px">
 <!-- wp:heading {"textAlign":"center","level":4} -->
 <h4 class="has-text-align-center" id="personal-95"><?php echo esc_html__( 'Professional', 'frost' ); ?> - $295</h4>
 <!-- /wp:heading -->

--- a/patterns/general-team-four-columns-main-background.php
+++ b/patterns/general-team-four-columns-main-background.php
@@ -7,8 +7,8 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"main","textColor":"background","layout":{"inherit":true}} -->
-<div class="wp-block-group alignfull has-background-color has-main-background-color has-text-color has-background has-link-color" style="margin-top:0px">
+<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull has-background-color has-foreground-background-color has-text-color has-background has-link-color" style="margin-top:0px">
 <!-- wp:spacer {"height":100} -->
 <div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->

--- a/patterns/general-team-four-columns-main-background.php
+++ b/patterns/general-team-four-columns-main-background.php
@@ -7,8 +7,8 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|base"}}},"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"main","textColor":"base","layout":{"inherit":true}} -->
-<div class="wp-block-group alignfull has-base-color has-main-background-color has-text-color has-background has-link-color" style="margin-top:0px">
+<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"main","textColor":"background","layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull has-background-color has-main-background-color has-text-color has-background has-link-color" style="margin-top:0px">
 <!-- wp:spacer {"height":100} -->
 <div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->

--- a/patterns/general-team-two-columns-main-background.php
+++ b/patterns/general-team-two-columns-main-background.php
@@ -7,8 +7,8 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"main","textColor":"background","layout":{"inherit":true}} -->
-<div class="wp-block-group alignfull has-background-color has-main-background-color has-text-color has-background has-link-color" style="margin-top:0px">
+<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull has-background-color has-foreground-background-color has-text-color has-background has-link-color" style="margin-top:0px">
 <!-- wp:spacer {"height":100} -->
 <div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->

--- a/patterns/general-team-two-columns-main-background.php
+++ b/patterns/general-team-two-columns-main-background.php
@@ -7,8 +7,8 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|base"}}},"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"main","textColor":"base","layout":{"inherit":true}} -->
-<div class="wp-block-group alignfull has-base-color has-main-background-color has-text-color has-background has-link-color" style="margin-top:0px">
+<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"main","textColor":"background","layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull has-background-color has-main-background-color has-text-color has-background has-link-color" style="margin-top:0px">
 <!-- wp:spacer {"height":100} -->
 <div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->

--- a/patterns/general-testimonials-boxes-main-background.php
+++ b/patterns/general-testimonials-boxes-main-background.php
@@ -16,8 +16,8 @@
 <div class="wp-block-columns alignwide">
 <!-- wp:column -->
 <div class="wp-block-column">
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"}}},"backgroundColor":"base"} -->
-<div class="wp-block-group has-base-background-color has-background" style="padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px">
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"}}},"backgroundColor":"background"} -->
+<div class="wp-block-group has-background-background-color has-background" style="padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px">
 <!-- wp:heading {"textAlign":"center","level":4,"style":{"typography":{"fontSize":72,"lineHeight":"1"}}} -->
 <h4 class="has-text-align-center" style="font-size:72px;line-height:1">“</h4>
 <!-- /wp:heading -->
@@ -33,8 +33,8 @@
 <!-- /wp:column -->
 <!-- wp:column -->
 <div class="wp-block-column">
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"}}},"backgroundColor":"base"} -->
-<div class="wp-block-group has-base-background-color has-background" style="padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px">
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"}}},"backgroundColor":"background"} -->
+<div class="wp-block-group has-background-background-color has-background" style="padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px">
 <!-- wp:heading {"textAlign":"center","level":4,"style":{"typography":{"fontSize":72,"lineHeight":"1"}}} -->
 <h4 class="has-text-align-center" style="font-size:72px;line-height:1">“</h4>
 <!-- /wp:heading -->
@@ -50,8 +50,8 @@
 <!-- /wp:column -->
 <!-- wp:column -->
 <div class="wp-block-column">
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"}}},"backgroundColor":"base"} -->
-<div class="wp-block-group has-base-background-color has-background" style="padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px">
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"}}},"backgroundColor":"background"} -->
+<div class="wp-block-group has-background-background-color has-background" style="padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px">
 <!-- wp:heading {"textAlign":"center","level":4,"style":{"typography":{"fontSize":72,"lineHeight":"1"}}} -->
 <h4 class="has-text-align-center" style="font-size:72px;line-height:1">“</h4>
 <!-- /wp:heading -->

--- a/patterns/general-testimonials-boxes-main-background.php
+++ b/patterns/general-testimonials-boxes-main-background.php
@@ -7,8 +7,8 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"main","layout":{"inherit":true}} -->
-<div class="wp-block-group alignfull has-main-background-color has-background" style="margin-top:0px">
+<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"foreground","layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull has-foreground-background-color has-background" style="margin-top:0px">
 <!-- wp:spacer {"height":100} -->
 <div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->

--- a/patterns/general-testimonials-boxes.php
+++ b/patterns/general-testimonials-boxes.php
@@ -7,8 +7,8 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px"}}},"textColor":"base","layout":{"inherit":true}} -->
-<div class="wp-block-group alignfull has-base-color has-text-color" style="margin-top:0px">
+<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px"}}},"textColor":"background","layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull has-background-color has-text-color" style="margin-top:0px">
 <!-- wp:spacer {"height":100} -->
 <div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->

--- a/patterns/general-testimonials-boxes.php
+++ b/patterns/general-testimonials-boxes.php
@@ -16,8 +16,8 @@
 <div class="wp-block-columns alignwide">
 <!-- wp:column -->
 <div class="wp-block-column">
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"}}},"backgroundColor":"main"} -->
-<div class="wp-block-group has-main-background-color has-background" style="padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px">
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"}}},"backgroundColor":"foreground"} -->
+<div class="wp-block-group has-foreground-background-color has-background" style="padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px">
 <!-- wp:heading {"textAlign":"center","level":4,"style":{"typography":{"fontSize":72,"lineHeight":"1"}}} -->
 <h4 class="has-text-align-center" style="font-size:72px;line-height:1">“</h4>
 <!-- /wp:heading -->
@@ -33,8 +33,8 @@
 <!-- /wp:column -->
 <!-- wp:column -->
 <div class="wp-block-column">
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"}}},"backgroundColor":"main"} -->
-<div class="wp-block-group has-main-background-color has-background" style="padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px">
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"}}},"backgroundColor":"foreground"} -->
+<div class="wp-block-group has-foreground-background-color has-background" style="padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px">
 <!-- wp:heading {"textAlign":"center","level":4,"style":{"typography":{"fontSize":72,"lineHeight":"1"}}} -->
 <h4 class="has-text-align-center" style="font-size:72px;line-height:1">“</h4>
 <!-- /wp:heading -->
@@ -50,8 +50,8 @@
 <!-- /wp:column -->
 <!-- wp:column -->
 <div class="wp-block-column">
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"}}},"backgroundColor":"main"} -->
-<div class="wp-block-group has-main-background-color has-background" style="padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px">
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"40px","right":"40px","bottom":"40px","left":"40px"}}},"backgroundColor":"foreground"} -->
+<div class="wp-block-group has-foreground-background-color has-background" style="padding-top:40px;padding-right:40px;padding-bottom:40px;padding-left:40px">
 <!-- wp:heading {"textAlign":"center","level":4,"style":{"typography":{"fontSize":72,"lineHeight":"1"}}} -->
 <h4 class="has-text-align-center" style="font-size:72px;line-height:1">“</h4>
 <!-- /wp:heading -->

--- a/patterns/general-testimonials-main-background.php
+++ b/patterns/general-testimonials-main-background.php
@@ -7,8 +7,8 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"main","textColor":"base","layout":{"inherit":true}} -->
-<div class="wp-block-group alignfull has-base-color has-main-background-color has-text-color has-background" style="margin-top:0px">
+<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"main","textColor":"background","layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull has-background-color has-main-background-color has-text-color has-background" style="margin-top:0px">
 <!-- wp:spacer {"height":100} -->
 <div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->

--- a/patterns/general-testimonials-main-background.php
+++ b/patterns/general-testimonials-main-background.php
@@ -7,8 +7,8 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"main","textColor":"background","layout":{"inherit":true}} -->
-<div class="wp-block-group alignfull has-background-color has-main-background-color has-text-color has-background" style="margin-top:0px">
+<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull has-background-color has-foreground-background-color has-text-color has-background" style="margin-top:0px">
 <!-- wp:spacer {"height":100} -->
 <div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->

--- a/patterns/header-default-main-background.php
+++ b/patterns/header-default-main-background.php
@@ -8,8 +8,8 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"30px","bottom":"30px"},"margin":{"top":"0px"}}},"backgroundColor":"main","layout":{"inherit":true}} -->
-<div class="wp-block-group alignfull has-main-background-color has-background" style="margin-top:0px;padding-top:30px;padding-bottom:30px">
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"30px","bottom":"30px"},"margin":{"top":"0px"}}},"backgroundColor":"foreground","layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull has-foreground-background-color has-background" style="margin-top:0px;padding-top:30px;padding-bottom:30px">
 <!-- wp:group {"align":"wide","layout":{"type":"flex","justifyContent":"space-between"}} -->
 <div class="wp-block-group alignwide">
 <!-- wp:site-title {"style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}}}} /-->

--- a/patterns/header-default-main-background.php
+++ b/patterns/header-default-main-background.php
@@ -12,8 +12,8 @@
 <div class="wp-block-group alignfull has-main-background-color has-background" style="margin-top:0px;padding-top:30px;padding-bottom:30px">
 <!-- wp:group {"align":"wide","layout":{"type":"flex","justifyContent":"space-between"}} -->
 <div class="wp-block-group alignwide">
-<!-- wp:site-title {"style":{"elements":{"link":{"color":{"text":"var:preset|color|base"}}}}} /-->
-<!-- wp:navigation {"textColor":"base","isResponsive":true,"style":{"spacing":{"blockGap":"20px"}}} -->
+<!-- wp:site-title {"style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}}}} /-->
+<!-- wp:navigation {"textColor":"background","isResponsive":true,"style":{"spacing":{"blockGap":"20px"}}} -->
 <!-- wp:page-list {"isNavigationChild":true,"showSubmenuIcon":true,"openSubmenusOnClick":false} /-->
 <!-- /wp:navigation -->
 </div>

--- a/patterns/page-home.php
+++ b/patterns/page-home.php
@@ -39,8 +39,8 @@
 <!-- /wp:spacer -->
 </div>
 <!-- /wp:group -->
-<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"main","textColor":"base","layout":{"inherit":true}} -->
-<div class="wp-block-group alignfull has-base-color has-main-background-color has-text-color has-background" style="margin-top:0px">
+<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"main","textColor":"background","layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull has-background-color has-main-background-color has-text-color has-background" style="margin-top:0px">
 <!-- wp:spacer {"height":100} -->
 <div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
@@ -55,11 +55,11 @@
 <!-- /wp:paragraph -->
 <!-- wp:buttons {"style":{"spacing":{"blockGap":"10px"}}} -->
 <div class="wp-block-buttons">
-<!-- wp:button {"className":"is-style-fill-base"} -->
-<div class="wp-block-button is-style-fill-base"><a class="wp-block-button__link"><?php echo esc_html__( 'Get Started', 'frost' ); ?></a></div>
+<!-- wp:button {"className":"is-style-fill-background"} -->
+<div class="wp-block-button is-style-fill-background"><a class="wp-block-button__link"><?php echo esc_html__( 'Get Started', 'frost' ); ?></a></div>
 <!-- /wp:button -->
-<!-- wp:button {"className":"is-style-outline-base"} -->
-<div class="wp-block-button is-style-outline-base"><a class="wp-block-button__link"><?php echo esc_html__( 'Learn More', 'frost' ); ?></a></div>
+<!-- wp:button {"className":"is-style-outline-background"} -->
+<div class="wp-block-button is-style-outline-background"><a class="wp-block-button__link"><?php echo esc_html__( 'Learn More', 'frost' ); ?></a></div>
 <!-- /wp:button -->
 </div>
 <!-- /wp:buttons -->
@@ -104,8 +104,8 @@
 <!-- /wp:spacer -->
 </div>
 <!-- /wp:group -->
-<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"main","textColor":"base","layout":{"inherit":true}} -->
-<div class="wp-block-group alignfull has-base-color has-main-background-color has-text-color has-background" style="margin-top:0px">
+<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"main","textColor":"background","layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull has-background-color has-main-background-color has-text-color has-background" style="margin-top:0px">
 <!-- wp:spacer {"height":100} -->
 <div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
@@ -122,8 +122,8 @@
 <div class="wp-block-column is-vertically-aligned-center" style="flex-basis:40%">
 <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"right","orientation":"horizontal"}} -->
 <div class="wp-block-buttons">
-<!-- wp:button {"style":{"spacing":{"padding":{"top":"15px","bottom":"15px","left":"25px","right":"25px"}},"border":{"radius":"0px"}},"className":"is-style-fill-base"} -->
-<div class="wp-block-button is-style-fill-base"><a class="wp-block-button__link" style="border-radius:0px;padding-top:15px;padding-right:25px;padding-bottom:15px;padding-left:25px"><?php echo esc_html__( 'Let’s Get Started', 'frost' ); ?> →</a></div>
+<!-- wp:button {"style":{"spacing":{"padding":{"top":"15px","bottom":"15px","left":"25px","right":"25px"}},"border":{"radius":"0px"}},"className":"is-style-fill-background"} -->
+<div class="wp-block-button is-style-fill-background"><a class="wp-block-button__link" style="border-radius:0px;padding-top:15px;padding-right:25px;padding-bottom:15px;padding-left:25px"><?php echo esc_html__( 'Let’s Get Started', 'frost' ); ?> →</a></div>
 <!-- /wp:button -->
 </div>
 <!-- /wp:buttons -->

--- a/patterns/page-home.php
+++ b/patterns/page-home.php
@@ -39,8 +39,8 @@
 <!-- /wp:spacer -->
 </div>
 <!-- /wp:group -->
-<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"main","textColor":"background","layout":{"inherit":true}} -->
-<div class="wp-block-group alignfull has-background-color has-main-background-color has-text-color has-background" style="margin-top:0px">
+<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull has-background-color has-foreground-background-color has-text-color has-background" style="margin-top:0px">
 <!-- wp:spacer {"height":100} -->
 <div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
@@ -104,8 +104,8 @@
 <!-- /wp:spacer -->
 </div>
 <!-- /wp:group -->
-<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"main","textColor":"background","layout":{"inherit":true}} -->
-<div class="wp-block-group alignfull has-background-color has-main-background-color has-text-color has-background" style="margin-top:0px">
+<!-- wp:group {"align":"full","style":{"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"foreground","textColor":"background","layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull has-background-color has-foreground-background-color has-text-color has-background" style="margin-top:0px">
 <!-- wp:spacer {"height":100} -->
 <div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->

--- a/patterns/page-link-main-background.php
+++ b/patterns/page-link-main-background.php
@@ -6,8 +6,8 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"main","textColor":"background","className":"is-style-full-height","layout":{"inherit":true}} -->
-<div class="wp-block-group alignfull is-style-full-height has-background-color has-main-background-color has-text-color has-background has-link-color" style="margin-top:0px">
+<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"foreground","textColor":"background","className":"is-style-full-height","layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull is-style-full-height has-background-color has-foreground-background-color has-text-color has-background has-link-color" style="margin-top:0px">
 <!-- wp:spacer {"height":100} -->
 <div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
@@ -20,7 +20,7 @@
 <!-- wp:paragraph {"align":"center"} -->
 <p class="has-text-align-center"><?php echo esc_html__( 'Company Name', 'frost' ); ?><br><a href="mailto:name@company.com">name@company.com</a></p>
 <!-- /wp:paragraph -->
-<!-- wp:social-links {"iconColor":"main","iconColorValue":"#000","iconBackgroundColor":"background","iconBackgroundColorValue":"#fff","size":"has-normal-icon-size","align":"center","layout":{"type":"flex","justifyContent":"center"},"style":{"spacing":{"blockGap":"10px"}}} -->
+<!-- wp:social-links {"iconColor":"foreground","iconColorValue":"#000","iconBackgroundColor":"background","iconBackgroundColorValue":"#fff","size":"has-normal-icon-size","align":"center","layout":{"type":"flex","justifyContent":"center"},"style":{"spacing":{"blockGap":"10px"}}} -->
 <ul class="wp-block-social-links aligncenter has-normal-icon-size has-icon-color has-icon-background-color">
 <!-- wp:social-link {"url":"#","service":"facebook"} /-->
 <!-- wp:social-link {"url":"#","service":"instagram"} /-->

--- a/patterns/page-link-main-background.php
+++ b/patterns/page-link-main-background.php
@@ -6,8 +6,8 @@
  */
 
 ?>
-<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|base"}}},"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"main","textColor":"base","className":"is-style-full-height","layout":{"inherit":true}} -->
-<div class="wp-block-group alignfull is-style-full-height has-base-color has-main-background-color has-text-color has-background has-link-color" style="margin-top:0px">
+<!-- wp:group {"align":"full","style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"margin":{"top":"0px"}}},"backgroundColor":"main","textColor":"background","className":"is-style-full-height","layout":{"inherit":true}} -->
+<div class="wp-block-group alignfull is-style-full-height has-background-color has-main-background-color has-text-color has-background has-link-color" style="margin-top:0px">
 <!-- wp:spacer {"height":100} -->
 <div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
@@ -20,7 +20,7 @@
 <!-- wp:paragraph {"align":"center"} -->
 <p class="has-text-align-center"><?php echo esc_html__( 'Company Name', 'frost' ); ?><br><a href="mailto:name@company.com">name@company.com</a></p>
 <!-- /wp:paragraph -->
-<!-- wp:social-links {"iconColor":"main","iconColorValue":"#000","iconBackgroundColor":"base","iconBackgroundColorValue":"#fff","size":"has-normal-icon-size","align":"center","layout":{"type":"flex","justifyContent":"center"},"style":{"spacing":{"blockGap":"10px"}}} -->
+<!-- wp:social-links {"iconColor":"main","iconColorValue":"#000","iconBackgroundColor":"background","iconBackgroundColorValue":"#fff","size":"has-normal-icon-size","align":"center","layout":{"type":"flex","justifyContent":"center"},"style":{"spacing":{"blockGap":"10px"}}} -->
 <ul class="wp-block-social-links aligncenter has-normal-icon-size has-icon-color has-icon-background-color">
 <!-- wp:social-link {"url":"#","service":"facebook"} /-->
 <!-- wp:social-link {"url":"#","service":"instagram"} /-->
@@ -34,20 +34,20 @@
 <!-- /wp:spacer -->
 <!-- wp:buttons {"layout":{"type":"flex","justifyContent":"center","orientation":"horizontal"},"style":{"spacing":{"blockGap":"10px"}}} -->
 <div class="wp-block-buttons">
-<!-- wp:button {"width":100,"style":{"border":{"radius":0}},"className":"is-style-fill-base"} -->
-<div class="wp-block-button has-custom-width wp-block-button__width-100 is-style-fill-base"><a class="wp-block-button__link no-border-radius"><?php echo esc_html__( 'Visit My Website', 'frost' ); ?></a></div>
+<!-- wp:button {"width":100,"style":{"border":{"radius":0}},"className":"is-style-fill-background"} -->
+<div class="wp-block-button has-custom-width wp-block-button__width-100 is-style-fill-background"><a class="wp-block-button__link no-border-radius"><?php echo esc_html__( 'Visit My Website', 'frost' ); ?></a></div>
 <!-- /wp:button -->
-<!-- wp:button {"width":100,"style":{"border":{"radius":0}},"className":"is-style-fill-base"} -->
-<div class="wp-block-button has-custom-width wp-block-button__width-100 is-style-fill-base"><a class="wp-block-button__link no-border-radius"><?php echo esc_html__( 'Read My Blog', 'frost' ); ?></a></div>
+<!-- wp:button {"width":100,"style":{"border":{"radius":0}},"className":"is-style-fill-background"} -->
+<div class="wp-block-button has-custom-width wp-block-button__width-100 is-style-fill-background"><a class="wp-block-button__link no-border-radius"><?php echo esc_html__( 'Read My Blog', 'frost' ); ?></a></div>
 <!-- /wp:button -->
-<!-- wp:button {"width":100,"style":{"border":{"radius":0}},"className":"is-style-fill-base"} -->
-<div class="wp-block-button has-custom-width wp-block-button__width-100 is-style-fill-base"><a class="wp-block-button__link no-border-radius"><?php echo esc_html__( 'Download My Ebook', 'frost' ); ?></a></div>
+<!-- wp:button {"width":100,"style":{"border":{"radius":0}},"className":"is-style-fill-background"} -->
+<div class="wp-block-button has-custom-width wp-block-button__width-100 is-style-fill-background"><a class="wp-block-button__link no-border-radius"><?php echo esc_html__( 'Download My Ebook', 'frost' ); ?></a></div>
 <!-- /wp:button -->
-<!-- wp:button {"width":100,"style":{"border":{"radius":0}},"className":"is-style-fill-base"} -->
-<div class="wp-block-button has-custom-width wp-block-button__width-100 is-style-fill-base"><a class="wp-block-button__link no-border-radius"><?php echo esc_html__( 'Follow My Newsletter', 'frost' ); ?></a></div>
+<!-- wp:button {"width":100,"style":{"border":{"radius":0}},"className":"is-style-fill-background"} -->
+<div class="wp-block-button has-custom-width wp-block-button__width-100 is-style-fill-background"><a class="wp-block-button__link no-border-radius"><?php echo esc_html__( 'Follow My Newsletter', 'frost' ); ?></a></div>
 <!-- /wp:button -->
-<!-- wp:button {"width":100,"style":{"border":{"radius":0}},"className":"is-style-fill-base"} -->
-<div class="wp-block-button has-custom-width wp-block-button__width-100 is-style-fill-base"><a class="wp-block-button__link no-border-radius"><?php echo esc_html__( 'Listen to My Podcast', 'frost' ); ?></a></div>
+<!-- wp:button {"width":100,"style":{"border":{"radius":0}},"className":"is-style-fill-background"} -->
+<div class="wp-block-button has-custom-width wp-block-button__width-100 is-style-fill-background"><a class="wp-block-button__link no-border-radius"><?php echo esc_html__( 'Listen to My Podcast', 'frost' ); ?></a></div>
 <!-- /wp:button --></div>
 <!-- /wp:buttons -->
 <!-- wp:spacer {"height":"40px"} -->

--- a/patterns/page-link.php
+++ b/patterns/page-link.php
@@ -20,7 +20,7 @@
 <!-- wp:paragraph {"align":"center"} -->
 <p class="has-text-align-center"><?php echo esc_html__( 'Company Name', 'frost' ); ?><br><a href="mailto:name@company.com">name@company.com</a></p>
 <!-- /wp:paragraph -->
-<!-- wp:social-links {"iconBackgroundColor":"main","iconBackgroundColorValue":"#000","size":"has-normal-icon-size","align":"center","layout":{"type":"flex","justifyContent":"center"},"style":{"spacing":{"blockGap":"10px"}}} -->
+<!-- wp:social-links {"iconBackgroundColor":"foreground","iconBackgroundColorValue":"#000","size":"has-normal-icon-size","align":"center","layout":{"type":"flex","justifyContent":"center"},"style":{"spacing":{"blockGap":"10px"}}} -->
 <ul class="wp-block-social-links aligncenter has-normal-icon-size has-icon-background-color">
 <!-- wp:social-link {"url":"#","service":"facebook"} /-->
 <!-- wp:social-link {"url":"#","service":"instagram"} /-->

--- a/style.css
+++ b/style.css
@@ -113,9 +113,9 @@ input[type="button"],
 input[type="submit"],
 .wp-block-post-comments input[type=submit],
 .wp-block-search__button {
-	border: 1px solid var(--wp--preset--color--main);
+	border: 1px solid var(--wp--preset--color--foreground);
 	border-radius: 0;
-	background-color: var(--wp--preset--color--main);
+	background-color: var(--wp--preset--color--foreground);
 	color: var(--wp--preset--color--background);
 	cursor: pointer;
 	font-size: var(--wp--preset--font-size--small);
@@ -135,8 +135,8 @@ input[type="submit"]:hover,
 .wp-block-search__button:focus,
 .wp-block-search__button:hover {
 	background-color: transparent;
-	border: 1px solid var(--wp--preset--color--main);
-	color: var(--wp--preset--color--main);
+	border: 1px solid var(--wp--preset--color--foreground);
+	color: var(--wp--preset--color--foreground);
 	text-decoration: none;
 }
 
@@ -148,7 +148,7 @@ input[type="submit"]:hover,
 
 .wp-block-button__link.has-black-color.has-background:focus,
 .wp-block-button__link.has-black-color.has-background:hover {
-	color: var(--wp--preset--color--main);
+	color: var(--wp--preset--color--foreground);
 }
 
 /* Button - Fill Background
@@ -157,7 +157,7 @@ input[type="submit"]:hover,
 .wp-block-button.is-style-fill-background .wp-block-button__link {
 	background-color: var(--wp--preset--color--background);
 	border: 1px solid var(--wp--preset--color--background);
-	color: var(--wp--preset--color--main);
+	color: var(--wp--preset--color--foreground);
 }
 
 .wp-block-button.is-style-fill-background .wp-block-button__link:focus,
@@ -174,14 +174,14 @@ input[type="submit"]:hover,
 	background-color: transparent;
 	border: 1px solid;
 	border-color: currentColor;
-	color: var(--wp--preset--color--main);
+	color: var(--wp--preset--color--foreground);
 	padding: 10px 25px;
 }
 
 .wp-block-button.is-style-outline .wp-block-button__link:focus,
 .wp-block-button.is-style-outline .wp-block-button__link:hover {
-	background-color: var(--wp--preset--color--main);
-	border-color: var(--wp--preset--color--main);
+	background-color: var(--wp--preset--color--foreground);
+	border-color: var(--wp--preset--color--foreground);
 	color: var(--wp--preset--color--background);
 }
 
@@ -198,7 +198,7 @@ input[type="submit"]:hover,
 .wp-block-button.is-style-outline-background .wp-block-button__link:focus,
 .wp-block-button.is-style-outline-background .wp-block-button__link:hover {
 	background-color: var(--wp--preset--color--background);
-	color: var(--wp--preset--color--main);
+	color: var(--wp--preset--color--foreground);
 }
 
 /* Calendar
@@ -206,17 +206,17 @@ input[type="submit"]:hover,
 
 .wp-block-calendar table caption,
 .wp-block-calendar table tbody {
-	color: var(--wp--preset--color--main);
+	color: var(--wp--preset--color--foreground);
 }
 
 .wp-block-calendar table th {
-	background-color: var(--wp--preset--color--main);
+	background-color: var(--wp--preset--color--foreground);
 	color: var(--wp--preset--color--background);
 }
 
 .wp-block-calendar tbody td,
 .wp-block-calendar th {
-	border: 1px solid var(--wp--preset--color--main);
+	border: 1px solid var(--wp--preset--color--foreground);
 	padding: 10px;
 }
 
@@ -227,7 +227,7 @@ input[type="submit"]:hover,
 .wp-block-gallery figcaption,
 .wp-block-image figcaption,
 .wp-block-table figcaption {
-	color: var(--wp--preset--color--main);
+	color: var(--wp--preset--color--foreground);
 	font-size: var(--wp--preset--font-size--small);
 	margin-bottom: 0;
 	margin-top: 10px;
@@ -255,7 +255,7 @@ input[type="submit"]:hover,
 
 *:not(.wp-block-code) > code,
 kbd {
-	background-color: var(--wp--preset--color--main);
+	background-color: var(--wp--preset--color--foreground);
 	color: var(--wp--preset--color--background);
 	font-size: var(--wp--preset--font-size--small);
 	padding: 5px 8px;
@@ -281,11 +281,11 @@ kbd {
 
 .wp-block-post-comments-form input:not([type=submit]),
 .wp-block-post-comments-form textarea {
-	border-color: var(--wp--preset--color--main);
+	border-color: var(--wp--preset--color--foreground);
 }
 
 .wp-block-post-comments-form input[type=submit] {
-	border: 1px solid var(--wp--preset--color--main);
+	border: 1px solid var(--wp--preset--color--foreground);
 }
 
 .wp-block-post-comments-form .form-submit {
@@ -306,7 +306,7 @@ kbd {
 }
 
 .wp-block-group.is-style-shadow-solid {
-	box-shadow: 5px 5px var(--wp--preset--color--main);
+	box-shadow: 5px 5px var(--wp--preset--color--foreground);
 }
 
 /* Image
@@ -360,7 +360,7 @@ ul li:where(.wp-block-list) {
 
 .wp-block-navigation__responsive-container-close,
 .wp-block-navigation__responsive-container-open {
-	border: 1px solid var(--wp--preset--color--main);
+	border: 1px solid var(--wp--preset--color--foreground);
 	padding: 2px;
 }
 
@@ -383,8 +383,8 @@ ul li:where(.wp-block-list) {
 --------------------------------------------- */
 
 .wp-block-navigation:not(.has-background) .wp-block-navigation__submenu-container {
-	background-color: var(--wp--preset--color--main);
-	border: var(--wp--preset--color--main);
+	background-color: var(--wp--preset--color--foreground);
+	border: var(--wp--preset--color--foreground);
 	color: var(--wp--preset--color--background);
 	padding: 10px;
 }
@@ -432,7 +432,7 @@ p.has-background {
 --------------------------------------------- */
 
 .wp-block-quote {
-	box-shadow: 5px 5px var(--wp--preset--color--main);
+	box-shadow: 5px 5px var(--wp--preset--color--foreground);
 }
 
 .wp-block-quote p:last-of-type {
@@ -487,11 +487,11 @@ p.has-background {
 }
 
 .wp-block-table thead {
-	border-bottom: 3px solid var(--wp--preset--color--main);
+	border-bottom: 3px solid var(--wp--preset--color--foreground);
 }
 
 .wp-block-table tfoot {
-	border-top: 3px solid var(--wp--preset--color--main);
+	border-top: 3px solid var(--wp--preset--color--foreground);
 }
 
 .wp-block-table td,
@@ -500,7 +500,7 @@ p.has-background {
 .wp-block-table.is-style-stripes td,
 .wp-block-table.is-style-stripes th,
 .wp-block-table.is-style-stripes tr {
-	border: 1px solid var(--wp--preset--color--main);
+	border: 1px solid var(--wp--preset--color--foreground);
 }
 
 .wp-block-table th {
@@ -534,9 +534,9 @@ select,
 textarea,
 .wp-block-search__input {
 	background-color: var(--wp--preset--color--background);
-	border: 1px solid var(--wp--preset--color--main);
+	border: 1px solid var(--wp--preset--color--foreground);
 	border-radius: 0;
-	color: var(--wp--preset--color--main);
+	color: var(--wp--preset--color--foreground);
 	font-family: var(--wp--preset--font-family--primary);
 	font-size: var(--wp--preset--font-size--medium);
 	font-weight: var(--wp--custom--font-weight--regular);
@@ -561,7 +561,7 @@ textarea {
 }
 
 ::placeholder {
-	color: var(--wp--preset--color--main);
+	color: var(--wp--preset--color--foreground);
 	font-size: var(--wp--preset--font-size--small);
 	opacity: 0.6;
 }
@@ -626,7 +626,7 @@ p:last-child,
 	.wp-block-navigation-item.is-style-fill a,
 	.wp-block-navigation-item.is-style-outline a:focus,
 	.wp-block-navigation-item.is-style-outline a:hover {
-		background-color: var(--wp--preset--color--main);
+		background-color: var(--wp--preset--color--foreground);
 	}
 
 	.wp-block-navigation-item.is-style-fill-background a,
@@ -637,7 +637,7 @@ p:last-child,
 
 	.wp-block-navigation-item.is-style-fill a,
 	.wp-block-navigation-item.is-style-outline a {
-		border: 1px solid var(--wp--preset--color--main);
+		border: 1px solid var(--wp--preset--color--foreground);
 	}
 
 	.wp-block-navigation-item.is-style-fill-background a,
@@ -651,7 +651,7 @@ p:last-child,
 	.wp-block-navigation-item.is-style-outline a,
 	.wp-block-navigation-item.is-style-outline-background a:focus,
 	.wp-block-navigation-item.is-style-outline-background a:hover {
-		color: var(--wp--preset--color--main);
+		color: var(--wp--preset--color--foreground);
 	}
 
 	.wp-block-navigation-item.is-style-fill a,

--- a/style.css
+++ b/style.css
@@ -116,7 +116,7 @@ input[type="submit"],
 	border: 1px solid var(--wp--preset--color--main);
 	border-radius: 0;
 	background-color: var(--wp--preset--color--main);
-	color: var(--wp--preset--color--base);
+	color: var(--wp--preset--color--background);
 	cursor: pointer;
 	font-size: var(--wp--preset--font-size--small);
 	font-weight: var(--wp--custom--font-weight--medium);
@@ -142,7 +142,7 @@ input[type="submit"]:hover,
 
 .wp-block-button__link.has-background:focus,
 .wp-block-button__link.has-background:hover {
-	color: var(--wp--preset--color--base);
+	color: var(--wp--preset--color--background);
 	filter: brightness(110%);
 }
 
@@ -151,20 +151,20 @@ input[type="submit"]:hover,
 	color: var(--wp--preset--color--main);
 }
 
-/* Button - Fill Base
+/* Button - Fill Background
 --------------------------------------------- */
 
-.wp-block-button.is-style-fill-base .wp-block-button__link {
-	background-color: var(--wp--preset--color--base);
-	border: 1px solid var(--wp--preset--color--base);
+.wp-block-button.is-style-fill-background .wp-block-button__link {
+	background-color: var(--wp--preset--color--background);
+	border: 1px solid var(--wp--preset--color--background);
 	color: var(--wp--preset--color--main);
 }
 
-.wp-block-button.is-style-fill-base .wp-block-button__link:focus,
-.wp-block-button.is-style-fill-base .wp-block-button__link:hover {
+.wp-block-button.is-style-fill-background .wp-block-button__link:focus,
+.wp-block-button.is-style-fill-background .wp-block-button__link:hover {
 	background-color: transparent;
-	border: 1px solid var(--wp--preset--color--base);
-	color: var(--wp--preset--color--base);
+	border: 1px solid var(--wp--preset--color--background);
+	color: var(--wp--preset--color--background);
 }
 
 /* Button - Outline
@@ -182,22 +182,22 @@ input[type="submit"]:hover,
 .wp-block-button.is-style-outline .wp-block-button__link:hover {
 	background-color: var(--wp--preset--color--main);
 	border-color: var(--wp--preset--color--main);
-	color: var(--wp--preset--color--base);
+	color: var(--wp--preset--color--background);
 }
 
-/* Button - Outline Base
+/* Button - Outline Background
 --------------------------------------------- */
 
-.wp-block-button.is-style-outline-base .wp-block-button__link {
+.wp-block-button.is-style-outline-background .wp-block-button__link {
 	background-color: transparent;
 	border: 1px solid;
-	border-color: var(--wp--preset--color--base);
-	color: var(--wp--preset--color--base);
+	border-color: var(--wp--preset--color--background);
+	color: var(--wp--preset--color--background);
 }
 
-.wp-block-button.is-style-outline-base .wp-block-button__link:focus,
-.wp-block-button.is-style-outline-base .wp-block-button__link:hover {
-	background-color: var(--wp--preset--color--base);
+.wp-block-button.is-style-outline-background .wp-block-button__link:focus,
+.wp-block-button.is-style-outline-background .wp-block-button__link:hover {
+	background-color: var(--wp--preset--color--background);
 	color: var(--wp--preset--color--main);
 }
 
@@ -211,7 +211,7 @@ input[type="submit"]:hover,
 
 .wp-block-calendar table th {
 	background-color: var(--wp--preset--color--main);
-	color: var(--wp--preset--color--base);
+	color: var(--wp--preset--color--background);
 }
 
 .wp-block-calendar tbody td,
@@ -256,7 +256,7 @@ input[type="submit"]:hover,
 *:not(.wp-block-code) > code,
 kbd {
 	background-color: var(--wp--preset--color--main);
-	color: var(--wp--preset--color--base);
+	color: var(--wp--preset--color--background);
 	font-size: var(--wp--preset--font-size--small);
 	padding: 5px 8px;
 	position: relative;
@@ -365,12 +365,12 @@ ul li:where(.wp-block-list) {
 }
 
 .has-background .wp-block-navigation__responsive-container-open {
-	border: 1px solid var(--wp--preset--color--base);
+	border: 1px solid var(--wp--preset--color--background);
 }
 
 .has-background .wp-block-navigation__responsive-container-open:focus,
 .has-background .wp-block-navigation__responsive-container-open:hover {
-	color: var(--wp--preset--color--base);
+	color: var(--wp--preset--color--background);
 }
 
 .wp-block-navigation:not([style*=text-decoration]) a,
@@ -385,7 +385,7 @@ ul li:where(.wp-block-list) {
 .wp-block-navigation:not(.has-background) .wp-block-navigation__submenu-container {
 	background-color: var(--wp--preset--color--main);
 	border: var(--wp--preset--color--main);
-	color: var(--wp--preset--color--base);
+	color: var(--wp--preset--color--background);
 	padding: 10px;
 }
 
@@ -533,7 +533,7 @@ input,
 select,
 textarea,
 .wp-block-search__input {
-	background-color: var(--wp--preset--color--base);
+	background-color: var(--wp--preset--color--background);
 	border: 1px solid var(--wp--preset--color--main);
 	border-radius: 0;
 	color: var(--wp--preset--color--main);
@@ -617,9 +617,9 @@ p:last-child,
 	--------------------------------------------- */
 
 	.wp-block-navigation-item.is-style-fill a,
-	.wp-block-navigation-item.is-style-fill-base a,
+	.wp-block-navigation-item.is-style-fill-background a,
 	.wp-block-navigation-item.is-style-outline a,
-	.wp-block-navigation-item.is-style-outline-base a {
+	.wp-block-navigation-item.is-style-outline-background a {
 		padding: 5px 15px;
 	}
 
@@ -629,10 +629,10 @@ p:last-child,
 		background-color: var(--wp--preset--color--main);
 	}
 
-	.wp-block-navigation-item.is-style-fill-base a,
-	.wp-block-navigation-item.is-style-outline-base a:focus,
-	.wp-block-navigation-item.is-style-outline-base a:hover {
-		background-color: var(--wp--preset--color--base);
+	.wp-block-navigation-item.is-style-fill-background a,
+	.wp-block-navigation-item.is-style-outline-background a:focus,
+	.wp-block-navigation-item.is-style-outline-background a:hover {
+		background-color: var(--wp--preset--color--background);
 	}
 
 	.wp-block-navigation-item.is-style-fill a,
@@ -640,35 +640,35 @@ p:last-child,
 		border: 1px solid var(--wp--preset--color--main);
 	}
 
-	.wp-block-navigation-item.is-style-fill-base a,
-	.wp-block-navigation-item.is-style-outline-base a {
-		border: 1px solid var(--wp--preset--color--base);
+	.wp-block-navigation-item.is-style-fill-background a,
+	.wp-block-navigation-item.is-style-outline-background a {
+		border: 1px solid var(--wp--preset--color--background);
 	}
 
 	.wp-block-navigation-item.is-style-fill a:focus,
 	.wp-block-navigation-item.is-style-fill a:hover,
-	.wp-block-navigation-item.is-style-fill-base a,
+	.wp-block-navigation-item.is-style-fill-background a,
 	.wp-block-navigation-item.is-style-outline a,
-	.wp-block-navigation-item.is-style-outline-base a:focus,
-	.wp-block-navigation-item.is-style-outline-base a:hover {
+	.wp-block-navigation-item.is-style-outline-background a:focus,
+	.wp-block-navigation-item.is-style-outline-background a:hover {
 		color: var(--wp--preset--color--main);
 	}
 
 	.wp-block-navigation-item.is-style-fill a,
-	.wp-block-navigation-item.is-style-fill-base a:focus,
-	.wp-block-navigation-item.is-style-fill-base a:hover,
+	.wp-block-navigation-item.is-style-fill-background a:focus,
+	.wp-block-navigation-item.is-style-fill-background a:hover,
 	.wp-block-navigation-item.is-style-outline a:focus,
 	.wp-block-navigation-item.is-style-outline a:hover,
-	.wp-block-navigation-item.is-style-outline-base a {
-		color: var(--wp--preset--color--base);
+	.wp-block-navigation-item.is-style-outline-background a {
+		color: var(--wp--preset--color--background);
 	}
 
 	.wp-block-navigation-item.is-style-fill a:focus,
 	.wp-block-navigation-item.is-style-fill a:hover,
-	.wp-block-navigation-item.is-style-fill-base a:focus,
-	.wp-block-navigation-item.is-style-fill-base a:hover,
+	.wp-block-navigation-item.is-style-fill-background a:focus,
+	.wp-block-navigation-item.is-style-fill-background a:hover,
 	.wp-block-navigation-item.is-style-outline a,
-	.wp-block-navigation-item.is-style-outline-base a {
+	.wp-block-navigation-item.is-style-outline-background a {
 		background-color: transparent;
 	}
 

--- a/styles/dark-mode.json
+++ b/styles/dark-mode.json
@@ -20,13 +20,13 @@
 					"color": "#00cccc"
 				},
 				{
-					"name": "Main",
-					"slug": "main",
+					"name": "Foreground",
+					"slug": "foreground",
 					"color": "#fff"
 				},
 				{
-					"name": "Base",
-					"slug": "base",
+					"name": "Background",
+					"slug": "background",
 					"color": "#000"
 				}
 			]

--- a/templates/page-cover.html
+++ b/templates/page-cover.html
@@ -3,8 +3,8 @@
 <main class="wp-block-group site-content" style="margin-top:0;padding-bottom:80px">
 	<!-- wp:cover {"useFeaturedImage":true,"dimRatio":80,"minHeight":480,"isDark":false,"align":"full"} -->
 	<div class="wp-block-cover alignfull is-light" style="min-height:480px"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-80 has-background-dim"></span><div class="wp-block-cover__inner-container">
-		<!-- wp:group {"style":{"elements":{"link":{"color":{"text":"var:preset|color|base"}}},"spacing":{"blockGap":"10px"}},"textColor":"base","layout":{"wideSize":"800px"}} -->
-		<div class="wp-block-group has-base-color has-text-color has-link-color">
+		<!-- wp:group {"style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"blockGap":"10px"}},"textColor":"background","layout":{"wideSize":"800px"}} -->
+		<div class="wp-block-group has-background-color has-text-color has-link-color">
 			<!-- wp:post-title {"textAlign":"center","level":1,"style":{"typography":{"fontStyle":"normal","fontWeight":"400"}},"fontSize":"max-60"} /-->
 		</div>
 		<!-- /wp:group -->

--- a/templates/single-cover.html
+++ b/templates/single-cover.html
@@ -3,8 +3,8 @@
 <main class="wp-block-group site-content" style="margin-top:0;padding-bottom:80px">
 	<!-- wp:cover {"useFeaturedImage":true,"dimRatio":80,"minHeight":480,"isDark":false,"align":"full"} -->
 	<div class="wp-block-cover alignfull is-light" style="min-height:480px"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-80 has-background-dim"></span><div class="wp-block-cover__inner-container">
-		<!-- wp:group {"style":{"elements":{"link":{"color":{"text":"var:preset|color|base"}}},"spacing":{"blockGap":"10px"}},"textColor":"base","layout":{"wideSize":"800px"}} -->
-		<div class="wp-block-group has-base-color has-text-color has-link-color">
+		<!-- wp:group {"style":{"elements":{"link":{"color":{"text":"var:preset|color|background"}}},"spacing":{"blockGap":"10px"}},"textColor":"background","layout":{"wideSize":"800px"}} -->
+		<div class="wp-block-group has-background-color has-text-color has-link-color">
 			<!-- wp:group {"style":{"spacing":{"blockGap":"10px"}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"center"},"fontSize":"small"} -->
 			<div class="wp-block-group has-small-font-size">
 				<!-- wp:post-date /-->

--- a/theme.json
+++ b/theme.json
@@ -89,13 +89,13 @@
 					"color": "#00cccc"
 				},
 				{
-					"name": "Main",
-					"slug": "main",
+					"name": "Foreground",
+					"slug": "foreground",
 					"color": "#000"
 				},
 				{
-					"name": "Base",
-					"slug": "base",
+					"name": "Background",
+					"slug": "background",
 					"color": "#fff"
 				}
 			]
@@ -210,7 +210,7 @@
 				},
 				"color": {
 					"background": "var(--wp--preset--color--main)",
-					"text": "var(--wp--preset--color--base)"
+					"text": "var(--wp--preset--color--background)"
 				},
 				"spacing": {
 					"padding": {
@@ -318,7 +318,7 @@
 				},
 				"color": {
 					"background": "var(--wp--preset--color--main)",
-					"text": "var(--wp--preset--color--base)"
+					"text": "var(--wp--preset--color--background)"
 				},
 				"spacing": {
 					"padding": {
@@ -415,7 +415,7 @@
 			}
 		},
 		"color": {
-			"background": "var(--wp--preset--color--base)",
+			"background": "var(--wp--preset--color--background)",
 			"text": "var(--wp--preset--color--main)"
 		},
 		"elements": {
@@ -428,7 +428,7 @@
 				},
 				"color": {
 					"background": "var(--wp--preset--color--main)",
-					"text": "var(--wp--preset--color--base)"
+					"text": "var(--wp--preset--color--background)"
 				},
 				"spacing": {
 					"padding": {

--- a/theme.json
+++ b/theme.json
@@ -209,7 +209,7 @@
 					"radius": "0"
 				},
 				"color": {
-					"background": "var(--wp--preset--color--main)",
+					"background": "var(--wp--preset--color--foreground)",
 					"text": "var(--wp--preset--color--background)"
 				},
 				"spacing": {
@@ -313,11 +313,11 @@
 			},
 			"core/preformatted": {
 				"border": {
-					"color": "var(--wp--preset--color--main)",
+					"color": "var(--wp--preset--color--foreground)",
 					"radius": "0"
 				},
 				"color": {
-					"background": "var(--wp--preset--color--main)",
+					"background": "var(--wp--preset--color--foreground)",
 					"text": "var(--wp--preset--color--background)"
 				},
 				"spacing": {
@@ -335,7 +335,7 @@
 			},
 			"core/pullquote": {
 				"border": {
-					"color": "var(--wp--preset--color--main)",
+					"color": "var(--wp--preset--color--foreground)",
 					"style": "solid",
 					"width": "1px"
 				},
@@ -350,7 +350,7 @@
 			},
 			"core/quote": {
 				"border": {
-					"color": "var(--wp--preset--color--main)",
+					"color": "var(--wp--preset--color--foreground)",
 					"style": "solid !important",
 					"width": "1px !important"
 				},
@@ -378,7 +378,7 @@
 			},
 			"core/separator": {
 				"color": {
-					"text": "var(--wp--preset--color--main)"
+					"text": "var(--wp--preset--color--foreground)"
 				},
 				"typography": {
 					"fontSize": "var(--wp--preset--font-size--large)"
@@ -416,18 +416,18 @@
 		},
 		"color": {
 			"background": "var(--wp--preset--color--background)",
-			"text": "var(--wp--preset--color--main)"
+			"text": "var(--wp--preset--color--foreground)"
 		},
 		"elements": {
 			"button": {
 				"border": {
-					"color": "var(--wp--preset--color--main)",
+					"color": "var(--wp--preset--color--foreground)",
 					"radius": "0",
 					"style": "solid",
 					"width": "1px"
 				},
 				"color": {
-					"background": "var(--wp--preset--color--main)",
+					"background": "var(--wp--preset--color--foreground)",
 					"text": "var(--wp--preset--color--background)"
 				},
 				"spacing": {
@@ -475,7 +475,7 @@
 			},
 			"link": {
 				"color": {
-					"text": "var(--wp--preset--color--main)"
+					"text": "var(--wp--preset--color--foreground)"
 				}
 			}
 		},


### PR DESCRIPTION
While testing WooCommerce integration with Frost theme I discovered that there is a slow standardization around color palette slugs, which would affect the compatibility of Frost with WooCommerce. 

Currently Frost leverages the [`main`](https://github.com/wpengine/frost/blob/trunk/theme.json#L93) and [`base`](https://github.com/wpengine/frost/blob/trunk/theme.json#L98) color variable naming convention. However, Twenty Twenty-Two has introduced the usage of [`foreground`](https://themes.trac.wordpress.org/browser/twentytwentytwo/1.2/theme.json#L113) and [`background`](https://themes.trac.wordpress.org/browser/twentytwentytwo/1.2/theme.json#L118), which in turn is being used [by WooCommerce to integrate global styling of elements like buttons](https://github.com/woocommerce/woocommerce/pull/33518/files#diff-4d8249aa26cad0c3201e91cebddb2c9adcf41c37c5de6f8f723b4936d2619892R48-R49). These are key to making Frost appear to seamlessly integrate with WooCommerce should it be activated.

Similarly, the Automattic themes are leveraging the same color slug naming convention of [`foreground`](https://github.com/Automattic/themes/blob/trunk/blockbase/theme.json#L79) and [`background`](https://github.com/Automattic/themes/blob/trunk/blockbase/theme.json#L84).

Since there is momentum around this standardization. I propose we make it easier for Frost users to leverage WooCommerce and potentially other plugins that will leverage this standardization in the future.