### PR TITLE
Update to fluid typography system

### DIFF
--- a/theme.json
+++ b/theme.json
@@ -117,6 +117,7 @@
 		},
 		"typography": {
 			"dropCap": false,
+			"fluid": true,
 			"fontFamilies": [
 				{
 					"fontFamily": "Outfit, sans-serif",
@@ -141,44 +142,103 @@
 			],
 			"fontSizes": [
 				{
+					"fluid": {
+						"min": "16px",
+						"max": "16px"
+					},
 					"name": "Small",
-					"slug": "small",
-					"size": "16px"
+					"size": "16px",
+					"slug": "small"
 				},
 				{
+					"fluid": {
+						"min": "18px",
+						"max": "20px"
+					},
 					"name": "Medium",
-					"slug": "medium",
-					"size": "20px"
+					"size": "20px",
+					"slug": "medium"
 				},
 				{
+					"fluid": {
+						"min": "21px",
+						"max": "24px"
+					},
 					"name": "Large",
-					"slug": "large",
-					"size": "24px"
+					"size": "24px",
+					"slug": "large"
 				},
 				{
+					"fluid": {
+						"min": "26px",
+						"max": "30px"
+					},
 					"name": "xLarge",
-					"slug": "x-large",
-					"size": "30px"
+					"size": "30px",
+					"slug": "x-large"
 				},
 				{
+					"fluid": {
+						"min": "24px",
+						"max": "36px"
+					},
 					"name": "36px",
-					"slug": "max-36",
-					"size": "clamp(24px, 3vw, 36px)"
+					"size": "36px",
+					"slug": "max-36"
 				},
 				{
+					"fluid": {
+						"min": "30px",
+						"max": "48px"
+					},
 					"name": "48px",
-					"slug": "max-48",
-					"size": "clamp(30px, 4vw, 48px)"
+					"size": "48px",
+					"slug": "max-48"
 				},
 				{
+					"fluid": {
+						"min": "36px",
+						"max": "60px"
+					},
 					"name": "60px",
-					"slug": "max-60",
-					"size": "clamp(36px, 5vw, 60px)"
+					"size": "60px",
+					"slug": "max-60"
 				},
 				{
+					"fluid": {
+						"min": "48px",
+						"max": "72px"
+					},
 					"name": "72px",
-					"slug": "max-72",
-					"size": "clamp(48px, 6vw, 72px)"
+					"size": "72px",
+					"slug": "max-72"
+				},
+				{
+					"fluid": {
+						"min": "24px",
+						"max": "36px"
+					},
+					"name": "Huge",
+					"size": "36px",
+					"slug": "huge"
+				},
+				{
+					"fluid": {
+						"min": "30px",
+						"max": "48px"
+					},
+					"name": "Gigantic",
+					"size": "48px",
+					"slug": "gigantic"
+				},
+				{
+					"fluid": {
+						"min": "36px",
+						"max": "60px"
+					},
+					"name": "Colossal",
+					"size": "60px",
+					"slug": "colossal"
 				}
 			]
 		},


### PR DESCRIPTION
Addresses #107

Related Gutenberg 13.8 fluid typography: https://github.com/WordPress/gutenberg/pull/39529

| Before | After |
|---------|------------|
| ![gutes local_ (1)](https://user-images.githubusercontent.com/405912/183137199-3c3e0376-dc1f-4e0c-afd3-c41d88465862.png) | ![gutes local_](https://user-images.githubusercontent.com/405912/183137258-2dbbe2ef-8b8c-415f-947f-c4979b022563.png) |
| ![gutes local_](https://user-images.githubusercontent.com/405912/183137335-1062da8e-4f99-4a1f-a6fd-40ec850173ed.png) | ![gutes local_ (2)](https://user-images.githubusercontent.com/405912/183137374-0f9f00d6-ccdf-4fa4-8b68-13dca3e9d33c.png) |
| ![gutes local_fluid-typography-test_ (1)](https://user-images.githubusercontent.com/405912/183137436-c1b68996-41dd-42c0-8eda-0e4e3bef99ca.png) | ![gutes local_fluid-typography-test_ copy](https://user-images.githubusercontent.com/405912/183137493-c41d862b-fe1e-4bc3-b538-280d801e53be.png) |
| ![gutes local_fluid-typography-test_](https://user-images.githubusercontent.com/405912/183137573-27f73248-e908-4e6a-b53b-de6d0b2dcb49.png) | ![gutes local_fluid-typography-test_](https://user-images.githubusercontent.com/405912/183137659-460b8cfb-7f3a-44a9-a2fa-2ca6d229f108.png) |