### PR TITLE
Fix Composer package type

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
 	"name": "wpengine/themes",
-	"type": "package",
+	"type": "wordpress-theme",
 	"description": "A collection of experimental block-based WordPress themes by WP Engine.",
 	"homepage": "https://github.com/wpengine/themes",
 	"license": "GPL-2.0-or-later",


### PR DESCRIPTION
Just that.
https://github.com/composer/installers/blob/main/src/Composer/Installers/WordPressInstaller.php#L10
